### PR TITLE
fix(seo): proper 404, per-page canonicals, no trailing-slash sitemap

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,5 +7,6 @@ import react from '@astrojs/react';
 // https://astro.build/config
 export default defineConfig({
     site: 'https://devfest.cz',
+    trailingSlash: 'never',
     integrations: [sitemap(), react()],
 });

--- a/firebase.json
+++ b/firebase.json
@@ -8,12 +8,6 @@
       "**/node_modules/**"
     ],
     "cleanUrls": true,
-    "trailingSlash": false,
-    "rewrites": [
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
-    ]
+    "trailingSlash": false
   }
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,16 +4,18 @@ import CookieBanner from '../components/CookieBanner.astro';
 interface Props {
 	title?: string;
 	description?: string;
+	noindex?: boolean;
 }
 
 const siteUrl = "https://devfest.cz";
 const {
 	title = "DevFest.cz 2026",
 	description = "DevFest.cz 2026 is global conference and festival for developers, geeks and technological experts focusing on Web/Mobile Development, Cybersecurity, AI/ML trends and more. Join us in Prague to experience unique community-built event!",
+	noindex = false,
 } = Astro.props;
 
 const ogImage = `${siteUrl}/og-image.jpg`;
-const canonicalUrl = `${siteUrl}/`;
+const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
 const ogImageAlt = "DevFest.cz 2026 conference banner";
 
 const jsonLd = JSON.stringify([
@@ -65,13 +67,17 @@ const jsonLd = JSON.stringify([
 		<meta name="generator" content={Astro.generator} />
 		<meta name="theme-color" content="#050505" />
 		<meta name="color-scheme" content="dark" />
-		<meta name="robots" content="index, follow" />
+		<meta name="robots" content={noindex ? "noindex, nofollow" : "index, follow"} />
 
 		<title>{title}</title>
 		<meta name="description" content={description} />
-		<link rel="canonical" href={canonicalUrl} />
-		<link rel="alternate" hreflang="en" href={canonicalUrl} />
-		<link rel="alternate" hreflang="x-default" href={canonicalUrl} />
+		{!noindex && (
+			<>
+				<link rel="canonical" href={canonicalUrl} />
+				<link rel="alternate" hreflang="en" href={canonicalUrl} />
+				<link rel="alternate" hreflang="x-default" href={canonicalUrl} />
+			</>
+		)}
 
 		<!-- Favicon -->
 		<link rel="icon" type="image/webp" href="/favicon-light.webp" media="(prefers-color-scheme: light)" />
@@ -107,7 +113,7 @@ const jsonLd = JSON.stringify([
 		<meta name="twitter:image:alt" content={ogImageAlt} />
 
 		<!-- Structured Data -->
-		<script type="application/ld+json" set:html={jsonLd} />
+		{!noindex && <script type="application/ld+json" set:html={jsonLd} />}
 
 		<!-- Firebase -->
 		<script>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,135 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Footer from '../components/Footer';
+---
+
+<BaseLayout
+	title="404 · DevFest.cz 2026"
+	description="The page you're looking for doesn't exist."
+	noindex
+>
+	<main class="landing">
+		<h1 class="title">
+			<img src="/logo.svg" alt="DevFest.cz 2026" class="logo" />
+		</h1>
+		<p class="code">404</p>
+		<p class="headline">Lost in the void.</p>
+		<p class="subtext">This page doesn't exist — or it never did.</p>
+		<a class="back-link" href="/">
+			<span class="back-arrow" aria-hidden="true">&#8592;</span>
+			Back to homepage
+		</a>
+		<div class="decoration-line" aria-hidden="true"></div>
+	</main>
+	<Footer client:load />
+</BaseLayout>
+
+<style lang="scss">
+	.landing {
+		min-height: 100dvh;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 4rem 1.5rem 6rem;
+		gap: 1.5rem;
+		text-align: center;
+		position: relative;
+		z-index: 1;
+	}
+
+	.title {
+		animation: fadeInUp 1s cubic-bezier(0.16, 1, 0.3, 1) 0.1s both;
+		line-height: 0;
+	}
+
+	.logo {
+		width: clamp(280px, 60vw, 520px);
+		height: auto;
+	}
+
+	.code {
+		font-family: 'Bebas Neue', sans-serif;
+		font-size: clamp(4rem, 14vw, 8rem);
+		letter-spacing: 0.16em;
+		color: var(--color-accent);
+		line-height: 1;
+		text-shadow: 0 0 40px rgba(204, 0, 0, 0.4);
+		animation: fadeInUp 1s cubic-bezier(0.16, 1, 0.3, 1) 0.25s both;
+	}
+
+	.headline {
+		font-family: 'Bebas Neue', sans-serif;
+		font-size: clamp(2rem, 6vw, 3.5rem);
+		letter-spacing: 0.08em;
+		color: var(--color-text);
+		animation: fadeInUp 1s cubic-bezier(0.16, 1, 0.3, 1) 0.4s both;
+	}
+
+	.subtext {
+		font-family: 'Share Tech Mono', monospace;
+		font-size: 1rem;
+		font-style: italic;
+		line-height: 1.6;
+		max-width: 380px;
+		color: #888;
+		animation: fadeIn 1.2s cubic-bezier(0.16, 1, 0.3, 1) 0.55s both;
+	}
+
+	.back-link {
+		font-family: 'Share Tech Mono', monospace;
+		font-size: 0.75rem;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--color-text);
+		text-decoration: none;
+		border: 1px solid rgba(204, 0, 0, 0.4);
+		padding: 0.7rem 2rem;
+		clip-path: polygon(8px 0%, 100% 0%, calc(100% - 8px) 100%, 0% 100%);
+		transition: background 0.25s, color 0.25s, border-color 0.25s;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-top: 0.5rem;
+		animation: fadeIn 1.2s cubic-bezier(0.16, 1, 0.3, 1) 0.7s both;
+
+		&:hover {
+			background: rgba(204, 0, 0, 0.15);
+			border-color: rgba(204, 0, 0, 0.7);
+			color: var(--color-text);
+		}
+	}
+
+	.back-arrow {
+		font-size: 0.85rem;
+		transition: transform 0.25s;
+
+		.back-link:hover & {
+			transform: translateX(-2px);
+		}
+	}
+
+	.decoration-line {
+		width: 40px;
+		height: 1px;
+		background: linear-gradient(90deg, transparent, rgba(204, 0, 0, 0.4), transparent);
+		margin-top: 1rem;
+		animation: fadeIn 1.2s cubic-bezier(0.16, 1, 0.3, 1) 0.8s both;
+	}
+
+	@keyframes fadeIn {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+
+	@keyframes fadeInUp {
+		from {
+			opacity: 0;
+			transform: translateY(24px);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary

Fixes a soft-404 problem keeping old DevFest URLs in Google's index, plus several inherited SEO issues in `BaseLayout`.

The recent `**` → `/index.html` rewrite ([1e84e38](https://github.com/gugcz/devfest-website/commit/1e84e383)) was making every unknown URL return **HTTP 200 with the homepage HTML** — Google reads that as a soft 404 and never deindexes the URL. Old URLs from previous DevFest years stayed in search results indefinitely.

## What changed

- **`firebase.json`** — removed the catch-all rewrite. Firebase now serves `dist/404.html` with HTTP 404 for unknown paths. Static Astro builds don't need an SPA fallback (each route has its own `index.html`).
- **`src/pages/404.astro`** — new 404 page styled to match the existing thank-you page.
- **`src/layouts/BaseLayout.astro`**:
  - New `noindex` prop. When `true`, also strips `canonical`, `hreflang`, and JSON-LD (none of those belong on a 404 — canonical pointing to homepage was itself a soft-404 signal, and JSON-LD reporting an `Event` named "404 · DevFest.cz 2026" was structured-data noise).
  - Canonical is now computed from `Astro.url.pathname`, so each page is self-referential. Previously every page declared the homepage as its canonical — that told Google `/privacy-policy` and the newsletter thank-you page were duplicates of `/`.
- **`astro.config.mjs`** — `trailingSlash: 'never'` so sitemap URLs match what Firebase actually serves. With `cleanUrls: true` + `trailingSlash: false` in Firebase, every URL in the old sitemap (`https://devfest.cz/privacy-policy/`) was returning a 301 redirect.

## Verified

After build:

| Page | robots | canonical | hreflang | JSON-LD | HTTP |
|---|---|---|---|---|---|
| `/` | index, follow | `devfest.cz/` | ✓ | ✓ | 200 |
| `/privacy-policy` | index, follow | `devfest.cz/privacy-policy` | ✓ | ✓ | 200 |
| `/newsletter-subscription-thank-you` | index, follow | `devfest.cz/newsletter-subscription-thank-you` | ✓ | ✓ | 200 |
| unknown URL | noindex, nofollow | — | — | — | **404** |

Sitemap now contains URLs without trailing slashes, matching Firebase's served paths (no 301 hops).

`curl -I http://localhost:4321/foo-not-found` against `npm run preview` returns `HTTP/1.1 404 Not Found` ✅

## Test plan

- [ ] After deploy: `curl -I https://devfest.cz/some-old-2024-url` returns `HTTP/2 404`
- [ ] `curl -s https://devfest.cz/privacy-policy | grep canonical` returns self-referential URL (not homepage)
- [ ] `curl -sI https://devfest.cz/privacy-policy` returns `HTTP/2 200` (no redirect)
- [ ] `curl -s https://devfest.cz/sitemap-0.xml` shows URLs without trailing slashes
- [ ] Visit a non-existent URL in browser — see styled 404 page
- [ ] [Google Search Console](https://search.google.com/search-console) → submit fresh sitemap, monitor *Pages* → *Soft 404* category should drain over 1–3 weeks

## Reviewer notes

The original rewrite was added to "avoid Firebase 404" — but for a static Astro site, the default Firebase behavior (serve `404.html` with HTTP 404) is what we actually want. If you remember a specific scenario where the rewrite was needed, please flag it before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)