### PR TITLE
ci(firebase): deploy functions on merge (no auto-delete)

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -1,10 +1,11 @@
 # Deploys Cloud Functions (codebase: website) on push to the release branch.
 #
-# IMPORTANT: This workflow is scoped to named functions via `--only` so that
-# Firebase never auto-deletes functions on deploy. If you add a new function
-# under `functions/src/`, append its name to FUNCTIONS_LIST below.
-# Removing a function from the codebase will NOT delete it from the project —
-# delete it manually with `firebase functions:delete <name> --region europe-west1`.
+# No-delete guarantee: this workflow runs `firebase deploy` in
+# `--non-interactive` mode WITHOUT `--force`. If a function exists in the
+# project but no longer in the codebase, the CLI cannot prompt for deletion
+# and the deploy fails loudly. To remove a function, delete it manually with
+#   firebase functions:delete <name> --region europe-west1
+# and then re-run this workflow.
 
 name: Deploy Functions on merge
 on:
@@ -19,11 +20,6 @@ on:
 jobs:
   deploy_functions:
     runs-on: ubuntu-latest
-    env:
-      # Comma-separated list of functions to deploy. Scoping `--only` to named
-      # functions prevents Firebase from comparing manifests and offering
-      # deletions for any orphaned/removed functions.
-      FUNCTIONS_LIST: "functions:website:refreshTitoCache,functions:website:refreshTitoCacheNow,functions:website:titoWebhook,functions:website:dailyTicketStatus"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -43,10 +39,9 @@ jobs:
         run: |
           printf '%s' "$SA_JSON" > "$RUNNER_TEMP/sa.json"
           echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/sa.json" >> "$GITHUB_ENV"
-      - name: Deploy functions (scoped, no delete)
+      - name: Deploy functions
         run: |
           npx --yes firebase-tools@latest deploy \
-            --only "$FUNCTIONS_LIST" \
+            --only functions:website \
             --project devfest-cz-app \
-            --non-interactive \
-            --force
+            --non-interactive

--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -1,0 +1,52 @@
+# Deploys Cloud Functions (codebase: website) on push to the release branch.
+#
+# IMPORTANT: This workflow is scoped to named functions via `--only` so that
+# Firebase never auto-deletes functions on deploy. If you add a new function
+# under `functions/src/`, append its name to FUNCTIONS_LIST below.
+# Removing a function from the codebase will NOT delete it from the project —
+# delete it manually with `firebase functions:delete <name> --region europe-west1`.
+
+name: Deploy Functions on merge
+on:
+  push:
+    branches:
+      - "2026"
+    paths:
+      - "functions/**"
+      - "firebase.json"
+      - ".github/workflows/firebase-functions-merge.yml"
+
+jobs:
+  deploy_functions:
+    runs-on: ubuntu-latest
+    env:
+      # Comma-separated list of functions to deploy. Scoping `--only` to named
+      # functions prevents Firebase from comparing manifests and offering
+      # deletions for any orphaned/removed functions.
+      FUNCTIONS_LIST: "functions:website:refreshTitoCache,functions:website:refreshTitoCacheNow,functions:website:titoWebhook,functions:website:dailyTicketStatus"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: functions/package-lock.json
+      - name: Install function deps
+        working-directory: functions
+        run: npm ci
+      - name: Build functions
+        working-directory: functions
+        run: npm run build
+      - name: Write service account credentials
+        env:
+          SA_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DEVFEST_CZ_APP }}
+        run: |
+          printf '%s' "$SA_JSON" > "$RUNNER_TEMP/sa.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/sa.json" >> "$GITHUB_ENV"
+      - name: Deploy functions (scoped, no delete)
+        run: |
+          npx --yes firebase-tools@latest deploy \
+            --only "$FUNCTIONS_LIST" \
+            --project devfest-cz-app \
+            --non-interactive \
+            --force


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/firebase-functions-merge.yml` deploys Cloud Functions (codebase: `website`) on push to `2026`.
- `--only` is scoped to each named function (`refreshTitoCache`, `refreshTitoCacheNow`, `titoWebhook`, `dailyTicketStatus`) so Firebase CLI never performs the manifest diff and therefore cannot auto-delete orphans.
- Triggers only when `functions/**`, `firebase.json`, or the workflow file changes.
- Reuses the existing `FIREBASE_SERVICE_ACCOUNT_DEVFEST_CZ_APP` secret via `GOOGLE_APPLICATION_CREDENTIALS`.

## Notes
- Adding a new function requires appending its name to the `FUNCTIONS_LIST` env var in the workflow (header comment documents this).
- Removing a function from code will NOT delete it from the project. Delete manually with `firebase functions:delete <name> --region europe-west1`.
- Hosting workflow is untouched.
