### PR TITLE
chore(tickets): drop refreshTitoCacheNow manual trigger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ functions/src/
     ├── tito-api.ts         # ti.to HTTP client + `projectRelease()`
     ├── tito-webhook.ts     # `verifyTitoSignature` + header constants + payload type
     ├── slack-client.ts     # `postToSlack()`
-    ├── refresh-cache.ts    # `refreshTitoCache`, `refreshTitoCacheNow`
+    ├── refresh-cache.ts    # `refreshTitoCache`
     ├── notify-purchase.ts  # `titoWebhook`
     └── daily-status.ts     # `dailyTicketStatus`
 ```
@@ -68,7 +68,6 @@ Functions exposed (region `europe-west1`):
 | Name | Trigger | Effect |
 | ---- | ------- | ------ |
 | `refreshTitoCache` | `onSchedule('every 1 hours')` | Fetch releases → write RTDB `/tickets` |
-| `refreshTitoCacheNow` | `onRequest` (`invoker: 'private'`) | Same as above, ad-hoc |
 | `titoWebhook` | `onRequest` (`invoker: 'public'`) | Verify `Tito-Signature` HMAC, post `ticket.completed` / `registration.finished` to Slack |
 | `dailyTicketStatus` | `onSchedule('every day 09:00', Europe/Prague)` | Fetch live releases from ti.to and post sales summary to Slack |
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,6 @@ echo 'TITO_EVENT_SLUG=your-event'      >> functions/.env
 
 # Deploy
 firebase deploy --only functions
-
-# Trigger an immediate ticket-cache refresh (otherwise wait up to an hour)
-gcloud functions call refreshTitoCacheNow --region europe-west1
 ```
 
 The default Cloud Functions service account has the IAM needed to write RTDB; no extra service-account JSON is required at runtime.
@@ -79,7 +76,6 @@ The default Cloud Functions service account has the IAM needed to write RTDB; no
 | Name | Trigger | Purpose |
 | ---- | ------- | ------- |
 | `refreshTitoCache` | Cloud Scheduler, hourly | Sync ti.to releases → RTDB `/tickets` |
-| `refreshTitoCacheNow` | HTTPS, `invoker: private` | Ad-hoc cache refresh for project members |
 | `titoWebhook` | HTTPS, public | Verifies `Tito-Signature` and posts purchase notifications to Slack |
 | `dailyTicketStatus` | Cloud Scheduler, `09:00 Europe/Prague` | Fetches live releases from ti.to and posts a sales summary to Slack |
 

--- a/functions/src/tickets/index.ts
+++ b/functions/src/tickets/index.ts
@@ -3,6 +3,6 @@
  * Add a new export here when a new ticket-related function is created.
  */
 
-export { refreshTitoCache, refreshTitoCacheNow } from './refresh-cache.js';
+export { refreshTitoCache } from './refresh-cache.js';
 export { titoWebhook } from './notify-purchase.js';
 export { dailyTicketStatus } from './daily-status.js';

--- a/functions/src/tickets/refresh-cache.ts
+++ b/functions/src/tickets/refresh-cache.ts
@@ -1,12 +1,11 @@
 /**
- * Scheduled and manual triggers that refresh the RTDB tickets cache from
- * the ti.to Admin API. The website reads `/tickets` directly so visitor
- * traffic never hits ti.to.
+ * Scheduled trigger that refreshes the RTDB tickets cache from the ti.to
+ * Admin API. The website reads `/tickets` directly so visitor traffic never
+ * hits ti.to.
  */
 
 import { logger } from 'firebase-functions/v2';
 import { onSchedule } from 'firebase-functions/v2/scheduler';
-import { onRequest } from 'firebase-functions/v2/https';
 
 import { db } from '../lib/admin.js';
 import { TITO_ACCOUNT_SLUG, TITO_API_TOKEN, TITO_EVENT_SLUG } from './params.js';
@@ -67,29 +66,5 @@ export const refreshTitoCache = onSchedule(
 	},
 	async () => {
 		await syncTickets();
-	},
-);
-
-/**
- * Manual HTTPS trigger for ad-hoc refreshes. `invoker: 'private'` requires
- * the caller to hold `cloudfunctions.invoker` IAM, so only authenticated
- * project members can run it (e.g. via `gcloud functions call`).
- */
-export const refreshTitoCacheNow = onRequest(
-	{
-		region: REGION,
-		secrets: [TITO_API_TOKEN],
-		timeoutSeconds: 120,
-		memory: '256MiB',
-		invoker: 'private',
-	},
-	async (_req, res) => {
-		try {
-			const result = await syncTickets();
-			res.status(200).json({ ok: true, ...result });
-		} catch (err) {
-			logger.error('refreshTitoCacheNow failed', err);
-			res.status(500).json({ ok: false, error: String(err) });
-		}
 	},
 );


### PR DESCRIPTION
## Summary

- Remove the unused `refreshTitoCacheNow` HTTPS trigger from the tickets domain — the hourly `refreshTitoCache` cron is sufficient.
- Update `README.md` and `CLAUDE.md` to drop the manual-trigger row from the functions table and the `gcloud functions call` example.

## Why

The ad-hoc trigger was added alongside the original ti.to → RTDB cache (#134) but is not needed in practice. Removing it shrinks the deployed surface and the docs.

## Manual prod cleanup after merge

CI runs functions deploys with `--no-auto-delete` (#135) to protect the shared mobile-app codebase, so a redeploy will leave the orphan function in place. After merging, delete it manually:

```bash
gcloud functions delete refreshTitoCacheNow \
  --region=europe-west1 --gen2 --project=devfest-cz-app
```

This also removes the lowercase `refreshtitocachenow` Cloud Run entry, which is the same underlying service.
