### PR TITLE
ci(firebase): write functions/.env from GH vars before deploy

### DIFF
--- a/.github/workflows/firebase-functions-merge.yml
+++ b/.github/workflows/firebase-functions-merge.yml
@@ -39,6 +39,15 @@ jobs:
         run: |
           printf '%s' "$SA_JSON" > "$RUNNER_TEMP/sa.json"
           echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/sa.json" >> "$GITHUB_ENV"
+      - name: Write functions env (non-secret ti.to slugs)
+        env:
+          TITO_ACCOUNT_SLUG: ${{ vars.TITO_ACCOUNT_SLUG }}
+          TITO_EVENT_SLUG: ${{ vars.TITO_EVENT_SLUG }}
+        run: |
+          {
+            printf 'TITO_ACCOUNT_SLUG=%s\n' "$TITO_ACCOUNT_SLUG"
+            printf 'TITO_EVENT_SLUG=%s\n' "$TITO_EVENT_SLUG"
+          } > functions/.env
       - name: Deploy functions
         run: |
           npx --yes firebase-tools@latest deploy \


### PR DESCRIPTION
## Summary

- Functions deploy needs the non-secret `defineString` params at build time; CI was failing with `In non-interactive mode but have no value for the following environment variables`.
- Firebase CLI loads these from `functions/.env`, which is gitignored. Write the file in CI from GitHub Actions repo variables before invoking `firebase deploy`.
- Values stay off-repo (set as repo Variables, not committed).

Required IAM roles for the deployer service account were granted out-of-band.
