### PR TITLE
chore(tickets): weekly Slack ticket status (was daily)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ functions/src/
     ├── slack-client.ts     # `postToSlack()`
     ├── refresh-cache.ts    # `refreshTitoCache`
     ├── notify-purchase.ts  # `titoWebhook`
-    └── daily-status.ts     # `dailyTicketStatus`
+    └── weekly-status.ts    # `weeklyTicketStatus`
 ```
 
 Functions exposed (region `europe-west1`):
@@ -69,7 +69,7 @@ Functions exposed (region `europe-west1`):
 | ---- | ------- | ------ |
 | `refreshTitoCache` | `onSchedule('every 1 hours')` | Fetch releases → write RTDB `/tickets` |
 | `titoWebhook` | `onRequest` (`invoker: 'public'`) | Verify `Tito-Signature` HMAC, post `ticket.completed` / `registration.finished` to Slack |
-| `dailyTicketStatus` | `onSchedule('every day 09:00', Europe/Prague)` | Fetch live releases from ti.to and post sales summary to Slack |
+| `weeklyTicketStatus` | `onSchedule('every monday 09:00', Europe/Prague)` | Fetch live releases from ti.to and post sales summary to Slack |
 
 Browser side: `src/components/Tickets.tsx` subscribes to `/tickets` via `firebase/database`'s `onValue`. `src/lib/tito.ts` holds browser-safe helpers (types, `filterDisplayable`, `checkoutUrl`, `formatPrice`). RTDB rules in `database.rules.json` (not wired into `firebase.json` — paste manually in console).
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The default Cloud Functions service account has the IAM needed to write RTDB; no
 | ---- | ------- | ------- |
 | `refreshTitoCache` | Cloud Scheduler, hourly | Sync ti.to releases → RTDB `/tickets` |
 | `titoWebhook` | HTTPS, public | Verifies `Tito-Signature` and posts purchase notifications to Slack |
-| `dailyTicketStatus` | Cloud Scheduler, `09:00 Europe/Prague` | Fetches live releases from ti.to and posts a sales summary to Slack |
+| `weeklyTicketStatus` | Cloud Scheduler, Mondays `09:00 Europe/Prague` | Fetches live releases from ti.to and posts a sales summary to Slack |
 
 Wire up the webhook in ti.to → Customize → Webhook Endpoints:
 1. Paste the deployed `titoWebhook` URL.

--- a/functions/src/tickets/index.ts
+++ b/functions/src/tickets/index.ts
@@ -5,4 +5,4 @@
 
 export { refreshTitoCache } from './refresh-cache.js';
 export { titoWebhook } from './notify-purchase.js';
-export { dailyTicketStatus } from './daily-status.js';
+export { weeklyTicketStatus } from './weekly-status.js';

--- a/functions/src/tickets/weekly-status.ts
+++ b/functions/src/tickets/weekly-status.ts
@@ -1,7 +1,7 @@
 /**
- * `dailyTicketStatus` — once a day, fetch releases directly from the ti.to
- * Admin API and post a sales summary to Slack. The cron is daily so the
- * extra ti.to request is negligible (1/day, well under the 60/min limit),
+ * `weeklyTicketStatus` — once a week, fetch releases directly from the ti.to
+ * Admin API and post a sales summary to Slack. The cron is weekly so the
+ * extra ti.to request is negligible (1/week, well under the 60/min limit),
  * and reading live data avoids any staleness from the hourly cache.
  */
 
@@ -95,7 +95,7 @@ function buildSlackMessage(summary: Summary): SlackPayload {
 	const blocks: unknown[] = [
 		{
 			type: 'header',
-			text: { type: 'plain_text', text: '📊 Daily ticket status', emoji: true },
+			text: { type: 'plain_text', text: '📊 Weekly ticket status', emoji: true },
 		},
 		{
 			type: 'section',
@@ -123,17 +123,17 @@ function buildSlackMessage(summary: Summary): SlackPayload {
 	];
 
 	return {
-		text: `Daily ticket status — total sold ${totalLabel}`,
+		text: `Weekly ticket status — total sold ${totalLabel}`,
 		blocks,
 	};
 }
 
 /**
- * Daily at 09:00 Europe/Prague. Fetches live data from ti.to (no RTDB).
+ * Weekly on Monday at 09:00 Europe/Prague. Fetches live data from ti.to (no RTDB).
  */
-export const dailyTicketStatus = onSchedule(
+export const weeklyTicketStatus = onSchedule(
 	{
-		schedule: 'every day 09:00',
+		schedule: 'every monday 09:00',
 		timeZone: 'Europe/Prague',
 		region: REGION,
 		secrets: [SLACK_WEBHOOK_URL, TITO_API_TOKEN],
@@ -156,7 +156,7 @@ export const dailyTicketStatus = onSchedule(
 		const summary = summarize(releases);
 		await postToSlack(SLACK_WEBHOOK_URL.value(), buildSlackMessage(summary));
 
-		logger.info('dailyTicketStatus posted', {
+		logger.info('weeklyTicketStatus posted', {
 			totalSold: summary.totalSold,
 			releaseCount: summary.releases.length,
 		});


### PR DESCRIPTION
## Summary

- Rename `dailyTicketStatus` → `weeklyTicketStatus` and move the schedule from `every day 09:00` to `every monday 09:00` (Europe/Prague). Daily cadence was noisier than the sales signal warranted; a weekly digest is enough.
- File renamed `functions/src/tickets/daily-status.ts` → `weekly-status.ts`. Slack header and log labels updated. Barrel re-export and docs (`CLAUDE.md`, `README.md`) updated.

## Why

Sales velocity does not change meaningfully day-over-day this far out from the event, so a daily Slack post adds noise. Weekly digest keeps the visibility without the spam.