### PR TITLE
fix(countdown): avoid SSR/client hydration mismatch

### DIFF
--- a/src/components/Countdown.tsx
+++ b/src/components/Countdown.tsx
@@ -36,9 +36,10 @@ interface StampDigitProps {
 	value: string;
 	idx: number;
 	code: string;
+	unit: string;
 }
 
-function StampDigit({ value, idx, code }: StampDigitProps) {
+function StampDigit({ value, idx, code, unit }: StampDigitProps) {
 	const [prev, setPrev] = useState(value);
 	const [animKey, setAnimKey] = useState(0);
 	const settleTimeoutRef = useRef<number | undefined>(undefined);
@@ -66,6 +67,10 @@ function StampDigit({ value, idx, code }: StampDigitProps) {
 			<span
 				className={`${s.digit} ${stamping ? s.digitStamping : ''}`}
 				key={animKey}
+				data-countdown-digit=""
+				data-unit={unit}
+				data-idx={idx}
+				suppressHydrationWarning
 			>
 				{value}
 			</span>
@@ -96,13 +101,15 @@ export default function Countdown() {
 			aria-live="polite"
 			aria-atomic="true"
 			aria-label={`Time until doors open: ${daysNum} days, ${hoursNum} hours, ${minutesNum} minutes, ${secondsNum} seconds`}
+			data-countdown-root=""
+			suppressHydrationWarning
 		>
 			{UNITS.map(({ key, label, code }) => (
 				<Fragment key={key}>
 					<div className={s.unit} aria-hidden="true">
 						<div className={s.cards}>
 							{time[key].split('').map((d, idx) => (
-								<StampDigit key={`${key}-${idx}`} value={d} idx={idx} code={code} />
+								<StampDigit key={`${key}-${idx}`} value={d} idx={idx} code={code} unit={key} />
 							))}
 						</div>
 						<span className={s.label}>{label}</span>

--- a/src/components/Countdown.tsx
+++ b/src/components/Countdown.tsx
@@ -73,10 +73,13 @@ function StampDigit({ value, idx, code }: StampDigitProps) {
 	);
 }
 
+const INITIAL_TIME: TimeLeft = { days: '000', hours: '00', minutes: '00', seconds: '00' };
+
 export default function Countdown() {
-	const [time, setTime] = useState<TimeLeft>(calcTimeLeft);
+	const [time, setTime] = useState<TimeLeft>(INITIAL_TIME);
 
 	useEffect(() => {
+		setTime(calcTimeLeft());
 		const id = setInterval(() => setTime(calcTimeLeft()), 1000);
 		return () => clearInterval(id);
 	}, []);

--- a/src/components/Countdown.tsx
+++ b/src/components/Countdown.tsx
@@ -36,10 +36,9 @@ interface StampDigitProps {
 	value: string;
 	idx: number;
 	code: string;
-	unit: string;
 }
 
-function StampDigit({ value, idx, code, unit }: StampDigitProps) {
+function StampDigit({ value, idx, code }: StampDigitProps) {
 	const [prev, setPrev] = useState(value);
 	const [animKey, setAnimKey] = useState(0);
 	const settleTimeoutRef = useRef<number | undefined>(undefined);
@@ -67,10 +66,6 @@ function StampDigit({ value, idx, code, unit }: StampDigitProps) {
 			<span
 				className={`${s.digit} ${stamping ? s.digitStamping : ''}`}
 				key={animKey}
-				data-countdown-digit=""
-				data-unit={unit}
-				data-idx={idx}
-				suppressHydrationWarning
 			>
 				{value}
 			</span>
@@ -101,15 +96,13 @@ export default function Countdown() {
 			aria-live="polite"
 			aria-atomic="true"
 			aria-label={`Time until doors open: ${daysNum} days, ${hoursNum} hours, ${minutesNum} minutes, ${secondsNum} seconds`}
-			data-countdown-root=""
-			suppressHydrationWarning
 		>
 			{UNITS.map(({ key, label, code }) => (
 				<Fragment key={key}>
 					<div className={s.unit} aria-hidden="true">
 						<div className={s.cards}>
 							{time[key].split('').map((d, idx) => (
-								<StampDigit key={`${key}-${idx}`} value={d} idx={idx} code={code} unit={key} />
+								<StampDigit key={`${key}-${idx}`} value={d} idx={idx} code={code} />
 							))}
 						</div>
 						<span className={s.label}>{label}</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,38 +51,6 @@ import Footer from '../components/Footer';
 				<aside class="hero-countdown" aria-label="Time until doors open">
 					<div class="section-label">Doors open in</div>
 					<Countdown client:load />
-					<script is:inline>
-						(function () {
-							var TARGET = Date.UTC(2026, 9, 30, 8, 0, 0);
-							var diff = TARGET - Date.now();
-							var d, h, m, s;
-							if (diff <= 0) {
-								d = '000'; h = '00'; m = '00'; s = '00';
-							} else {
-								d = String(Math.floor(diff / 86400000)).padStart(3, '0');
-								h = String(Math.floor((diff % 86400000) / 3600000)).padStart(2, '0');
-								m = String(Math.floor((diff % 3600000) / 60000)).padStart(2, '0');
-								s = String(Math.floor((diff % 60000) / 1000)).padStart(2, '0');
-							}
-							var t = { days: d, hours: h, minutes: m, seconds: s };
-							document.querySelectorAll('[data-countdown-digit]').forEach(function (el) {
-								var unit = el.getAttribute('data-unit');
-								var idx = parseInt(el.getAttribute('data-idx'), 10);
-								var v = t[unit];
-								if (v && v[idx] !== undefined) el.textContent = v[idx];
-							});
-							var root = document.querySelector('[data-countdown-root]');
-							if (root) {
-								root.setAttribute('aria-label',
-									'Time until doors open: ' +
-									parseInt(t.days, 10) + ' days, ' +
-									parseInt(t.hours, 10) + ' hours, ' +
-									parseInt(t.minutes, 10) + ' minutes, ' +
-									parseInt(t.seconds, 10) + ' seconds'
-								);
-							}
-						})();
-					</script>
 				</aside>
 			</div>
 		</section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,6 +51,38 @@ import Footer from '../components/Footer';
 				<aside class="hero-countdown" aria-label="Time until doors open">
 					<div class="section-label">Doors open in</div>
 					<Countdown client:load />
+					<script is:inline>
+						(function () {
+							var TARGET = Date.UTC(2026, 9, 30, 8, 0, 0);
+							var diff = TARGET - Date.now();
+							var d, h, m, s;
+							if (diff <= 0) {
+								d = '000'; h = '00'; m = '00'; s = '00';
+							} else {
+								d = String(Math.floor(diff / 86400000)).padStart(3, '0');
+								h = String(Math.floor((diff % 86400000) / 3600000)).padStart(2, '0');
+								m = String(Math.floor((diff % 3600000) / 60000)).padStart(2, '0');
+								s = String(Math.floor((diff % 60000) / 1000)).padStart(2, '0');
+							}
+							var t = { days: d, hours: h, minutes: m, seconds: s };
+							document.querySelectorAll('[data-countdown-digit]').forEach(function (el) {
+								var unit = el.getAttribute('data-unit');
+								var idx = parseInt(el.getAttribute('data-idx'), 10);
+								var v = t[unit];
+								if (v && v[idx] !== undefined) el.textContent = v[idx];
+							});
+							var root = document.querySelector('[data-countdown-root]');
+							if (root) {
+								root.setAttribute('aria-label',
+									'Time until doors open: ' +
+									parseInt(t.days, 10) + ' days, ' +
+									parseInt(t.hours, 10) + ' hours, ' +
+									parseInt(t.minutes, 10) + ' minutes, ' +
+									parseInt(t.seconds, 10) + ' seconds'
+								);
+							}
+						})();
+					</script>
 				</aside>
 			</div>
 		</section>


### PR DESCRIPTION
## Summary
- Seed `Countdown` state with stable zeros so SSR markup matches the first client render.
- Compute real time and start the 1s interval inside `useEffect`, so server `Date.now()` no longer diverges from client `Date.now()` at hydration time.

## Why
Console error in production:

> Hydration failed because the server rendered text didn't match the client.

The mismatch was in the seconds digit (and the `aria-label`): SSR rendered with the server clock, then React rehydrated with the client clock a moment later, so React threw the whole subtree away and regenerated it on the client.

## Tradeoff
There's a brief flash of `000 / 00 / 00 / 00` before the mount effect runs and paints the real countdown. The alternative — switching the island to `client:only="react"` — would skip SSR entirely and cause empty-space layout shift on first paint, which is worse for the hero section.

## Test plan
- [ ] `npm run dev`, open `/`, confirm no hydration warning in the console.
- [ ] Verify the countdown briefly shows zeros, then immediately snaps to the real time and ticks every second.
- [ ] Verify `aria-label` on the countdown updates each second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)