### PR TITLE
feat(site): add partners section with deck CTA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## PR conventions
+
+- **Do not add a `## Test plan` section to PR descriptions.** The maintainer verifies changes manually and the checklist adds noise. Keep PR bodies to Summary / Why / Follow-up only.
+
 # DevFest Website
 
 Conference landing page for DevFest.cz 2026, built with Astro 6 and deployed to Firebase Hosting.

--- a/src/components/Partners.astro
+++ b/src/components/Partners.astro
@@ -1,5 +1,7 @@
 ---
-// TODO: replace with real partnership deck URL (PDF, Google Slides, Notion etc.)
+// Partnership deck is still in production. Once it lands (PDF / Google Slides / Notion),
+// flip `DECK_READY` to true and set `PRESENTATION_URL`.
+const DECK_READY = false;
 const PRESENTATION_URL = '#partners-deck-todo';
 const FILIP = { name: 'Filip Goszler', role: 'Partnerships', email: 'filip@gug.cz' };
 ---
@@ -24,11 +26,22 @@ const FILIP = { name: 'Filip Goszler', role: 'Partnerships', email: 'filip@gug.c
 			</div>
 
 			<div class="partners-cta-wrap">
-				<a class="partners-cta" href={PRESENTATION_URL} target="_blank" rel="noopener noreferrer">
-					<span>See partnership deck</span>
-					<span class="partners-cta-arrow" aria-hidden="true">→</span>
-				</a>
-				<p class="partners-cta-note">Tiers, perks, audience stats — one PDF.</p>
+				{DECK_READY ? (
+					<a class="partners-cta" href={PRESENTATION_URL} target="_blank" rel="noopener noreferrer">
+						<span>See partnership deck</span>
+						<span class="partners-cta-arrow" aria-hidden="true">→</span>
+					</a>
+				) : (
+					<span class="partners-cta partners-cta-soon" aria-disabled="true" role="text">
+						<span class="partners-cta-label">Partnership deck</span>
+						<span class="partners-cta-stamp" aria-hidden="true">Coming soon</span>
+					</span>
+				)}
+				<p class="partners-cta-note">
+					{DECK_READY
+						? 'Tiers, perks, audience stats — one PDF.'
+						: 'Brochure lands soon. In the meantime, drop Filip a line.'}
+				</p>
 			</div>
 		</div>
 	</div>
@@ -246,6 +259,65 @@ const FILIP = { name: 'Filip Goszler', role: 'Partnerships', email: 'filip@gug.c
 		}
 	}
 
+	.partners-cta-soon {
+		background: rgba(80, 60, 50, 0.55);
+		border-color: rgba(120, 90, 80, 0.6);
+		color: rgba(240, 237, 230, 0.8);
+		cursor: not-allowed;
+		gap: 0.7rem;
+		padding: 0.95rem 1.6rem 0.95rem 2.4rem;
+
+		&::after {
+			content: '';
+			position: absolute;
+			top: 50%;
+			left: 1.2rem;
+			width: 8px;
+			height: 8px;
+			border-radius: 50%;
+			background: rgba(204, 0, 0, 0.7);
+			box-shadow: 0 0 8px rgba(204, 0, 0, 0.55);
+			transform: translateY(-50%);
+			animation: deckPulse 2s ease-in-out infinite;
+		}
+
+		&:hover,
+		&:focus-visible {
+			background: rgba(80, 60, 50, 0.55);
+			transform: rotate(-1.5deg);
+			box-shadow: 0 2px 0 rgba(0, 0, 0, 0.25);
+		}
+	}
+
+	.partners-cta-label {
+		opacity: 0.92;
+	}
+
+	.partners-cta-stamp {
+		font-family: 'Share Tech Mono', monospace;
+		font-size: 0.6rem;
+		letter-spacing: 0.28em;
+		text-transform: uppercase;
+		padding: 0.22rem 0.55rem;
+		background: rgba(204, 0, 0, 0.78);
+		color: #F5EBDC;
+		border: 1px solid rgba(0, 0, 0, 0.35);
+		box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+		border-radius: 1px;
+		transform: rotate(3deg);
+	}
+
+	@keyframes deckPulse {
+		0%, 100% { opacity: 0.6; }
+		50% { opacity: 1; }
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.partners-cta-soon::after {
+			animation: none;
+		}
+	}
+
 	.partners-cta-note {
 		font-family: 'IM Fell English', serif;
 		font-style: italic;
@@ -273,6 +345,23 @@ const FILIP = { name: 'Filip Goszler', role: 'Partnerships', email: 'filip@gug.c
 
 		.partners-cta {
 			justify-content: center;
+		}
+
+		.partners-cta-soon {
+			flex-wrap: wrap;
+			gap: 0.55rem;
+			padding: 0.9rem 1.2rem 0.9rem 2rem;
+			white-space: normal;
+
+			&::after {
+				left: 0.9rem;
+			}
+		}
+
+		.partners-cta-stamp {
+			font-size: 0.55rem;
+			letter-spacing: 0.24em;
+			padding: 0.2rem 0.45rem;
 		}
 
 		.partners-cta-note {

--- a/src/components/Partners.astro
+++ b/src/components/Partners.astro
@@ -1,0 +1,288 @@
+---
+// TODO: replace with real partnership deck URL (PDF, Google Slides, Notion etc.)
+const PRESENTATION_URL = '#partners-deck-todo';
+const FILIP = { name: 'Filip Goszler', role: 'Partnerships', email: 'filip@gug.cz' };
+---
+
+<section id="partners" aria-labelledby="partners-title">
+	<div class="partners-inner">
+		<div class="section-label">The accomplices</div>
+		<h2 id="partners-title" class="section-title">
+			Without our partners,<br /><span class="red">this case stays cold.</span>
+		</h2>
+		<p class="partners-lede">
+			DevFest.cz is a non-profit community conference. Every speaker travel ticket, every coffee,
+			every late-night neon glow is bankrolled by partners who back the Czech tech community.
+			Grow your brand in front of hundreds of engineers, founders, and the press.
+		</p>
+
+		<div class="partners-block">
+			<div class="contact-card">
+				<div class="contact-role">{FILIP.role}</div>
+				<div class="contact-name">{FILIP.name}</div>
+				<a class="contact-email" href={`mailto:${FILIP.email}`}>{FILIP.email}</a>
+			</div>
+
+			<div class="partners-cta-wrap">
+				<a class="partners-cta" href={PRESENTATION_URL} target="_blank" rel="noopener noreferrer">
+					<span>See partnership deck</span>
+					<span class="partners-cta-arrow" aria-hidden="true">→</span>
+				</a>
+				<p class="partners-cta-note">Tiers, perks, audience stats — one PDF.</p>
+			</div>
+		</div>
+	</div>
+</section>
+
+<style lang="scss">
+	#partners {
+		position: relative;
+		padding: 6rem 3rem;
+		background: var(--color-bg);
+		overflow: hidden;
+
+		&::before {
+			content: '';
+			position: absolute;
+			inset: 0;
+			background: radial-gradient(ellipse 50% 60% at 12% 18%, rgba(204, 0, 0, 0.06) 0%, transparent 60%);
+			pointer-events: none;
+			z-index: 0;
+		}
+	}
+
+	.partners-inner {
+		position: relative;
+		z-index: 1;
+		max-width: 1080px;
+		margin: 0 auto;
+		width: 100%;
+	}
+
+	.section-label {
+		font-family: 'Share Tech Mono', monospace;
+		font-size: 0.65rem;
+		letter-spacing: 0.4em;
+		text-transform: uppercase;
+		color: rgba(240, 237, 230, 0.55);
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		margin-bottom: 2rem;
+
+		&::after {
+			content: '';
+			flex: 0 0 60px;
+			height: 1px;
+			background: rgba(204, 0, 0, 0.45);
+		}
+	}
+
+	.section-title {
+		font-family: 'Bebas Neue', sans-serif;
+		font-size: clamp(2.5rem, 5vw, 4.5rem);
+		line-height: 0.92;
+		letter-spacing: 0.02em;
+		color: var(--color-text);
+		margin-bottom: 1.5rem;
+
+		.red {
+			color: rgba(204, 0, 0, 0.85);
+		}
+	}
+
+	.partners-lede {
+		font-family: 'IM Fell English', serif;
+		font-style: italic;
+		font-size: 1.05rem;
+		line-height: 1.7;
+		color: var(--color-grey);
+		max-width: 60ch;
+		margin-bottom: 3rem;
+	}
+
+	.partners-block {
+		display: grid;
+		grid-template-columns: minmax(260px, 1fr) auto;
+		align-items: center;
+		gap: 2.5rem;
+		padding: 2.4rem 2.2rem;
+		position: relative;
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		background:
+			linear-gradient(180deg, rgba(204, 0, 0, 0.05) 0%, transparent 60%),
+			rgba(255, 255, 255, 0.02);
+		border-radius: 1px;
+
+		&::before {
+			content: '';
+			position: absolute;
+			top: -1px;
+			left: -1px;
+			width: 60px;
+			height: 60px;
+			border-top: 2px solid rgba(204, 0, 0, 0.55);
+			border-left: 2px solid rgba(204, 0, 0, 0.55);
+			pointer-events: none;
+		}
+
+		&::after {
+			content: '';
+			position: absolute;
+			bottom: -1px;
+			right: -1px;
+			width: 60px;
+			height: 60px;
+			border-bottom: 2px solid rgba(204, 0, 0, 0.55);
+			border-right: 2px solid rgba(204, 0, 0, 0.55);
+			pointer-events: none;
+		}
+	}
+
+	.contact-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+		padding: 1.2rem 1.3rem 1.3rem;
+		background: rgba(0, 0, 0, 0.3);
+		border: 1px solid rgba(240, 237, 230, 0.08);
+		border-radius: 1px;
+		min-width: 0;
+	}
+
+	.contact-role {
+		font-family: 'Share Tech Mono', monospace;
+		font-size: 0.6rem;
+		letter-spacing: 0.32em;
+		text-transform: uppercase;
+		color: rgba(240, 237, 230, 0.45);
+	}
+
+	.contact-name {
+		font-family: 'Bebas Neue', sans-serif;
+		font-size: 1.5rem;
+		letter-spacing: 0.06em;
+		color: var(--color-text);
+	}
+
+	.contact-email {
+		font-family: 'Share Tech Mono', monospace;
+		font-size: 0.9rem;
+		letter-spacing: 0.04em;
+		color: rgba(240, 237, 230, 0.9);
+		text-decoration: none;
+		border-bottom: 1px dashed rgba(204, 0, 0, 0.5);
+		padding-bottom: 1px;
+		margin-top: 0.4rem;
+		align-self: flex-start;
+		transition: color 0.2s, border-color 0.2s;
+		word-break: break-all;
+
+		&:hover,
+		&:focus-visible {
+			color: var(--color-accent);
+			border-color: var(--color-accent);
+			outline: none;
+		}
+	}
+
+	.partners-cta-wrap {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.9rem;
+	}
+
+	.partners-cta {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.9rem;
+		font-family: 'Share Tech Mono', monospace;
+		font-size: 0.85rem;
+		letter-spacing: 0.3em;
+		text-transform: uppercase;
+		background: #8B1818;
+		color: #F5EBDC;
+		border: 2px solid #8B1818;
+		border-radius: 1px;
+		padding: 1.05rem 2.4rem;
+		text-decoration: none;
+		position: relative;
+		overflow: hidden;
+		transform: rotate(-1.5deg);
+		box-shadow: 0 2px 0 rgba(0, 0, 0, 0.25);
+		transition: background 0.2s, transform 0.2s, box-shadow 0.2s;
+		white-space: nowrap;
+
+		&::before {
+			content: '';
+			position: absolute;
+			inset: 0;
+			background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='30'%3E%3Cfilter id='t'%3E%3CfeTurbulence type='turbulence' baseFrequency='0.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='80' height='30' filter='url(%23t)' opacity='0.16'/%3E%3C/svg%3E");
+			background-size: 80px 30px;
+			mix-blend-mode: multiply;
+			pointer-events: none;
+		}
+
+		&:hover,
+		&:focus-visible {
+			background: var(--color-accent-hot);
+			transform: rotate(-1.5deg) translateY(-1px);
+			box-shadow: 0 4px 14px rgba(204, 0, 0, 0.5), 0 2px 0 rgba(0, 0, 0, 0.25);
+			outline: none;
+		}
+
+		&:active {
+			transform: rotate(-1.5deg) translateY(0);
+		}
+	}
+
+	.partners-cta-arrow {
+		font-size: 0.95rem;
+		transition: transform 0.25s;
+
+		.partners-cta:hover & {
+			transform: translateX(3px);
+		}
+	}
+
+	.partners-cta-note {
+		font-family: 'IM Fell English', serif;
+		font-style: italic;
+		font-size: 0.95rem;
+		color: rgba(240, 237, 230, 0.55);
+		max-width: 32ch;
+		text-align: center;
+		margin: 0;
+	}
+
+	@media (max-width: 900px) {
+		#partners {
+			padding: 4.5rem 1.5rem;
+		}
+
+		.partners-block {
+			grid-template-columns: 1fr;
+			gap: 1.8rem;
+			padding: 1.8rem 1.5rem 2rem;
+		}
+
+		.partners-cta-wrap {
+			align-items: stretch;
+		}
+
+		.partners-cta {
+			justify-content: center;
+		}
+
+		.partners-cta-note {
+			max-width: none;
+		}
+	}
+
+	@media (max-width: 600px) {
+		#partners {
+			padding: 3.5rem 1.1rem;
+		}
+	}
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Countdown from '../components/Countdown';
 import NewsletterForm from '../components/NewsletterForm';
 import Footer from '../components/Footer.astro';
+import Partners from '../components/Partners.astro';
 // import Tickets from '../components/Tickets'; // TICKETS HIDDEN — restore when sale opens
 ---
 
@@ -78,7 +79,8 @@ import Footer from '../components/Footer.astro';
 		<Tickets client:visible />
 		-->
 
-
+		<!-- PARTNERS -->
+		<Partners />
 
 		<!-- NEWSLETTER -->
 		<section id="newsletter">


### PR DESCRIPTION
## Summary

- Adds a new `Partners.astro` section to the landing page (between the ticker and the newsletter) with the same noir/detective look as the rest of the site.
- Section copy follows the [2025 partners page](https://2025.devfest.cz/partners) intent: invite sponsors to back the community conference.
- Includes a single contact card (Filip Goszler — partnerships lead for the 2026 edition) and a stamped red CTA labelled **See partnership deck**.

## Why

We need a "Become a partner" call-to-action on the site so sponsors can reach out before tickets open. The 2025 page used a full tier table; for now we are keeping the landing block lean — one contact, one link — and will expand once the deck is finalised.

## Follow-up

The deck URL is a placeholder: `PRESENTATION_URL = '#partners-deck-todo'` in `src/components/Partners.astro`. Replace this with the real PDF / Google Slides / Notion link before announcing the conference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)