### PR TITLE
ci(hosting): skip preview deploy for dependabot PRs

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 jobs:
   build_and_preview:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Dependabot-authored PRs (e.g. [#147](https://github.com/gugcz/devfest-website/pull/147)) fail the `Deploy to Firebase Hosting on PR` job because Dependabot runs with restricted secret access and the `FIREBASE_SERVICE_ACCOUNT_*` secret is not available, so `action-hosting-deploy` errors out.
- Adds `github.actor != 'dependabot[bot]'` to the existing job-level `if:` so lockfile-only bumps stop tripping red checks.
- Non-Dependabot PRs from the same repo are unaffected; fork PRs remain blocked by the existing `head.repo.full_name == github.repository` guard.

## Verification
- `git diff` confirms a single-line change to `.github/workflows/firebase-hosting-pull-request.yml`.