### PR TITLE
fix(a11y): cover /partners + /contact in axe audit, fix ticker contrast

### DIFF
--- a/scripts/a11y.mjs
+++ b/scripts/a11y.mjs
@@ -11,6 +11,8 @@ const DIST = path.resolve('dist');
 const PORT = 4321;
 const PATHS = [
 	'/',
+	'/partners/',
+	'/contact/',
 	'/privacy-policy/',
 	'/newsletter-subscription-thank-you/',
 	'/404.html',

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -385,12 +385,12 @@ import Footer from '../components/Footer.astro';
 		font-size: 0.7rem;
 		letter-spacing: 0.25em;
 		text-transform: uppercase;
-		color: var(--color-bg);
+		color: #F5EBDC;
 		padding: 0 3rem;
 	}
 
 	.ticker-sep {
-		color: rgba(0, 0, 0, 0.4);
+		color: rgba(245, 235, 220, 0.45);
 	}
 
 	@keyframes ticker {

--- a/src/pages/partners.astro
+++ b/src/pages/partners.astro
@@ -242,12 +242,12 @@ const FILIP = { name: 'Filip Goszler', role: 'Partnerships', email: 'filip@gug.c
 		font-size: 0.7rem;
 		letter-spacing: 0.25em;
 		text-transform: uppercase;
-		color: var(--color-bg);
+		color: #F5EBDC;
 		padding: 0 3rem;
 	}
 
 	.ticker-sep {
-		color: rgba(0, 0, 0, 0.4);
+		color: rgba(245, 235, 220, 0.45);
 	}
 
 	@keyframes ticker {


### PR DESCRIPTION
## Summary

- Add `/partners/` and `/contact/` to the axe-core audit path list in `scripts/a11y.mjs` so the CI a11y job covers them on every PR.
- Fix a contrast bug surfaced by the audit: the red ticker bands on both pages rendered text in `#050505` on `#A01818` — measured **2.56:1**, fails WCAG 2.2 AA (4.5:1 required). Switch ticker text to `#F5EBDC` cream, matching the homepage ticker (~7.2:1).

## Why

`/partners` and `/contact` were merged after the axe audit landed (#150) and never got added to the audit path list, so the regression slipped through. Adding them now means future changes on those pages get blocked on contrast / labels / landmarks the same way the rest of the site does.

## Verification

- `npm run build` — clean.
- `npm run a11y` — all 6 pages (`/`, `/partners/`, `/contact/`, `/privacy-policy/`, `/newsletter-subscription-thank-you/`, `/404.html`) pass WCAG 2.2 AA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)