### PR TITLE
feat(footer): expand with sitemap, event meta, organizer for SEO

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,48 +2,127 @@
 const SOCIALS = [
 	{
 		href: 'https://x.com/devfest_cz',
-		label: 'X (Twitter)',
+		label: 'DevFest.cz on X (Twitter)',
 		path: 'M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z',
 	},
 	{
 		href: 'https://www.facebook.com/DevFestCZ',
-		label: 'Facebook',
+		label: 'DevFest.cz on Facebook',
 		path: 'M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z',
 	},
 	{
 		href: 'https://bsky.app/profile/devfest.cz',
-		label: 'Bluesky',
+		label: 'DevFest.cz on Bluesky',
 		path: 'M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479.785 2.627 3.59 3.513 6.182 3.2-4.574.552-8.657 2.444-5.282 7.777C4.537 25.405 8.093 20.463 12 16.08c3.907 4.383 7.376 9.199 10.476 5.144 3.375-5.333-.708-7.225-5.282-7.777 2.592.313 5.397-.573 6.182-3.2.246-.828.624-5.788.624-6.479 0-.688-.139-1.86-.902-2.203-.659-.3-1.664-.62-4.3 1.24C16.046 4.748 13.087 8.687 12 10.8z',
 	},
 	{
 		href: 'https://www.linkedin.com/company/gugcz/',
-		label: 'LinkedIn',
+		label: 'GDG Czech Republic on LinkedIn',
 		path: 'M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z',
 	},
 	{
 		href: 'https://www.youtube.com/@gug_cz',
-		label: 'YouTube',
+		label: 'GDG Czech Republic on YouTube',
 		path: 'M23.498 6.186a3.016 3.016 0 00-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 00.502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 002.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 002.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z',
 	},
 ] as const;
+
+const SITEMAP = [
+	{ href: '/', label: 'Home' },
+	{ href: '/#newsletter', label: 'Newsletter' },
+	{ href: 'https://2025.devfest.cz', label: "Last year's edition", external: true },
+	{ href: '/privacy-policy', label: 'Privacy Policy' },
+] as const;
 ---
 
-<footer class="footer">
-	<div>Organized with ♥️ by GUG.cz, z.s. © 2026, All Rights Reserved</div>
-	<nav class="socials" aria-label="Social media">
-		{
-			SOCIALS.map(({ href, label, path }) => (
-				<a class="social-link" href={href} target="_blank" rel="noopener noreferrer" aria-label={label}>
-					<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-						<path d={path} />
-					</svg>
-				</a>
-			))
-		}
-	</nav>
-	<div class="contact">
-		<span class="contact-label">Contact</span>
-		<a class="email" href="mailto:info@devfest.cz">info@devfest.cz</a>
+<footer class="footer" role="contentinfo">
+	<div class="footer-inner">
+		<div class="footer-grid">
+			<section class="col col-brand" aria-labelledby="footer-brand">
+				<h2 id="footer-brand" class="col-title">DevFest.cz 2026</h2>
+				<p class="brand-tagline">
+					Prague's developer conference &mdash; Web, Mobile, Cybersecurity, AI/ML.
+				</p>
+				<address class="contact">
+					<a class="email" href="mailto:info@devfest.cz">info@devfest.cz</a>
+				</address>
+			</section>
+
+			<nav class="col" aria-labelledby="footer-sitemap">
+				<h2 id="footer-sitemap" class="col-title">Sitemap</h2>
+				<ul class="link-list">
+					{
+						SITEMAP.map(({ href, label, external }) => (
+							<li>
+								<a
+									class="footer-link"
+									href={href}
+									{...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+								>
+									{label}
+									{external && <span class="ext" aria-hidden="true"> &#8599;</span>}
+								</a>
+							</li>
+						))
+					}
+				</ul>
+			</nav>
+
+			<section class="col" aria-labelledby="footer-event">
+				<h2 id="footer-event" class="col-title">Event</h2>
+				<dl class="event-meta">
+					<dt>Date</dt>
+					<dd>
+						<time datetime="2026-10-30">30 October 2026</time>
+					</dd>
+					<dt>Place</dt>
+					<dd>Prague, Czech Republic</dd>
+					<dt>Format</dt>
+					<dd>In-person</dd>
+				</dl>
+			</section>
+
+			<section class="col col-organizer" aria-labelledby="footer-organizer">
+				<h2 id="footer-organizer" class="col-title">Organizer</h2>
+				<p class="org">
+					Organized with &#9829; by
+					<a
+						class="footer-link org-link"
+						href="https://gug.cz"
+						target="_blank"
+						rel="noopener noreferrer"
+					>GDG Czech Republic (GUG.cz, z.s.)<span class="ext" aria-hidden="true"> &#8599;</span></a>
+				</p>
+				<nav class="socials" aria-label="Follow DevFest.cz on social media">
+					{
+						SOCIALS.map(({ href, label, path }) => (
+							<a
+								class="social-link"
+								href={href}
+								target="_blank"
+								rel="noopener noreferrer me"
+								aria-label={label}
+							>
+								<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+									<path d={path} />
+								</svg>
+							</a>
+						))
+					}
+				</nav>
+			</section>
+		</div>
+
+		<div class="footer-bottom">
+			<small class="copyright">
+				&copy; 2026 GUG.cz, z.s. &mdash; All rights reserved.
+			</small>
+			<small class="bottom-links">
+				<a class="footer-link" href="/privacy-policy">Privacy Policy</a>
+				<span class="bottom-sep" aria-hidden="true">///</span>
+				<a class="footer-link" href="mailto:info@devfest.cz">Contact</a>
+			</small>
+		</div>
 	</div>
 </footer>
 
@@ -52,16 +131,11 @@ const SOCIALS = [
 		position: relative;
 		width: 100%;
 		z-index: 2;
-		padding: 2.6rem 2.5rem 1.8rem;
+		padding: 3rem 2.5rem 1.6rem;
 		border-top: 1px solid rgba(240, 237, 230, 0.08);
 		background: #030303;
-		display: grid;
-		grid-template-columns: 1fr auto 1fr;
-		align-items: center;
 		font-family: 'Share Tech Mono', monospace;
-		font-size: 0.85rem;
-		letter-spacing: 0.04em;
-		color: rgba(240, 237, 230, 0.55);
+		color: rgba(240, 237, 230, 0.65);
 
 		&::before {
 			content: '';
@@ -74,31 +148,205 @@ const SOCIALS = [
 			background: rgba(204, 0, 0, 0.4);
 		}
 
+		@media (max-width: 700px) {
+			padding: 2.4rem 1.5rem 1.4rem;
+		}
+	}
+
+	.footer-inner {
+		max-width: 1200px;
+		margin: 0 auto;
+	}
+
+	.footer-grid {
+		display: grid;
+		grid-template-columns: 1.4fr 1fr 1fr 1.4fr;
+		gap: 2.5rem;
+		padding-bottom: 2.4rem;
+		border-bottom: 1px solid rgba(240, 237, 230, 0.06);
+
+		@media (max-width: 960px) {
+			grid-template-columns: 1fr 1fr;
+			gap: 2rem;
+		}
+
 		@media (max-width: 500px) {
 			grid-template-columns: 1fr;
-			justify-items: center;
-			gap: 1rem;
+			gap: 1.8rem;
 			text-align: center;
-			padding: 2.2rem 1.5rem 1.5rem;
+			justify-items: center;
 		}
+	}
+
+	.col {
+		display: flex;
+		flex-direction: column;
+		gap: 0.9rem;
+		min-width: 0;
+	}
+
+	.col-title {
+		font-family: 'Share Tech Mono', monospace;
+		font-size: 0.78rem;
+		letter-spacing: 0.24em;
+		text-transform: uppercase;
+		color: rgba(240, 237, 230, 0.85);
+		font-weight: normal;
+		margin: 0;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.6rem;
+
+		&::after {
+			content: '';
+			flex: 0 0 28px;
+			height: 1px;
+			background: rgba(204, 0, 0, 0.35);
+		}
+	}
+
+	.brand-tagline {
+		font-family: 'IM Fell English', serif;
+		font-style: italic;
+		font-size: 0.92rem;
+		line-height: 1.55;
+		color: rgba(240, 237, 230, 0.6);
+		max-width: 32ch;
+
+		@media (max-width: 500px) {
+			margin: 0 auto;
+		}
+	}
+
+	.contact {
+		font-style: normal;
+	}
+
+	.link-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.55rem;
+	}
+
+	.footer-link {
+		font-family: 'Share Tech Mono', monospace;
+		font-size: 0.88rem;
+		letter-spacing: 0.04em;
+		color: rgba(240, 237, 230, 0.78);
+		text-decoration: none;
+		border-bottom: 1px dashed transparent;
+		padding-bottom: 1px;
+		transition: color 0.2s ease, border-color 0.2s ease;
+
+		&:hover,
+		&:focus-visible {
+			color: var(--color-accent-hot);
+			border-bottom-color: var(--color-accent-hot);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--color-accent-hot);
+			outline-offset: 3px;
+		}
+	}
+
+	.ext {
+		font-size: 0.85em;
+		opacity: 0.65;
+	}
+
+	.event-meta {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		column-gap: 1rem;
+		row-gap: 0.4rem;
+		margin: 0;
+		font-size: 0.88rem;
+
+		@media (max-width: 500px) {
+			justify-content: center;
+			grid-template-columns: auto auto;
+		}
+
+		dt {
+			font-size: 0.72rem;
+			letter-spacing: 0.2em;
+			text-transform: uppercase;
+			color: rgba(240, 237, 230, 0.5);
+			align-self: center;
+		}
+
+		dd {
+			margin: 0;
+			color: rgba(240, 237, 230, 0.82);
+			letter-spacing: 0.04em;
+		}
+	}
+
+	.email {
+		font-family: 'Special Elite', cursive;
+		font-size: 0.95rem;
+		color: rgba(240, 237, 230, 0.88);
+		text-decoration: none;
+		border-bottom: 1px dashed rgba(240, 237, 230, 0.5);
+		padding-bottom: 1px;
+		transition: color 0.2s ease, border-color 0.2s ease;
+
+		&:hover,
+		&:focus-visible {
+			color: var(--color-accent-hot);
+			border-bottom-color: var(--color-accent-hot);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--color-accent-hot);
+			outline-offset: 3px;
+		}
+	}
+
+	.col-organizer {
+		gap: 1rem;
+	}
+
+	.org {
+		font-family: 'Share Tech Mono', monospace;
+		font-size: 0.85rem;
+		line-height: 1.6;
+		color: rgba(240, 237, 230, 0.65);
+		max-width: 34ch;
+
+		@media (max-width: 500px) {
+			margin: 0 auto;
+		}
+	}
+
+	.org-link {
+		display: inline;
 	}
 
 	.socials {
 		display: flex;
 		align-items: center;
-		gap: 0.6rem;
-		padding: 0 1rem;
+		gap: 0.4rem;
+		flex-wrap: wrap;
+
+		@media (max-width: 500px) {
+			justify-content: center;
+		}
 	}
 
 	.social-link {
-		color: rgba(240, 237, 230, 0.7);
-		transition: color 0.25s ease, background 0.25s ease;
+		color: rgba(240, 237, 230, 0.72);
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		width: 2.75rem;
-		height: 2.75rem;
+		width: 2.5rem;
+		height: 2.5rem;
 		border-radius: 4px;
+		transition: color 0.25s ease, background 0.25s ease;
 
 		&:hover,
 		&:focus-visible {
@@ -112,53 +360,36 @@ const SOCIALS = [
 		}
 	}
 
-	.contact {
+	.footer-bottom {
+		padding-top: 1.4rem;
 		display: flex;
-		flex-direction: column;
-		align-items: flex-end;
-		gap: 0.3rem;
-		justify-self: end;
+		justify-content: space-between;
+		align-items: center;
+		gap: 1rem;
+		flex-wrap: wrap;
+		font-size: 0.78rem;
+		letter-spacing: 0.06em;
+		color: rgba(240, 237, 230, 0.5);
 
 		@media (max-width: 500px) {
-			align-items: center;
-			justify-self: center;
+			justify-content: center;
+			text-align: center;
 		}
 	}
 
-	.contact-label {
-		text-transform: uppercase;
-		letter-spacing: 0.24em;
-		color: rgba(240, 237, 230, 0.65);
-		font-size: 0.78rem;
+	.copyright {
+		font-size: inherit;
+	}
+
+	.bottom-links {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.6rem;
-
-		&::after {
-			content: '';
-			width: 32px;
-			height: 1px;
-			background: rgba(204, 0, 0, 0.35);
-		}
+		gap: 0.7rem;
+		font-size: inherit;
 	}
 
-	.email {
-		font-family: 'Special Elite', cursive;
-		color: rgba(240, 237, 230, 0.85);
-		text-decoration: none;
-		transition: color 0.25s ease, border-color 0.25s ease;
-		border-bottom: 1px dashed rgba(240, 237, 230, 0.5);
-		padding-bottom: 1px;
-
-		&:hover,
-		&:focus-visible {
-			color: var(--color-accent-hot);
-			border-bottom-color: var(--color-accent-hot);
-		}
-
-		&:focus-visible {
-			outline: 2px solid var(--color-accent-hot);
-			outline-offset: 3px;
-		}
+	.bottom-sep {
+		color: rgba(240, 237, 230, 0.2);
+		user-select: none;
 	}
 </style>


### PR DESCRIPTION
## Summary

Footer rebuilt from a single-row layout (socials + email + copyright) into a richer 4-column structure with crawlable links, semantic markup, and event metadata. Goal: improve internal linking and SEO signals from every page.

### What's in the footer now

- **Brand** — Site name (h2), tagline, contact email wrapped in `<address>`
- **Sitemap nav** — Home, Newsletter anchor, Last year's edition (2025.devfest.cz), Privacy Policy
- **Event** — Date / Place / Format as `<dl>`, date wrapped in `<time datetime="2026-10-30">`
- **Organizer** — Linked to `gug.cz`, followed by social icons
- **Bottom bar** — Copyright + Privacy/Contact small print

### SEO / a11y changes

- `role="contentinfo"` on `<footer>`, labeled `<nav>` regions, `<section aria-labelledby>` per column
- Descriptive social `aria-label`s (e.g. "DevFest.cz on X" instead of "X")
- `rel="me"` on social links — identity verification signal
- `<h2>` per footer section → cleaner document outline for crawlers
- `<time datetime>` + `<dl>` for machine-readable event metadata
- External links carry `rel="noopener noreferrer"` + a small `↗` glyph

### Responsive behavior

- 4 columns ≥ 960px
- 2 columns 500–960px
- 1 centered column < 500px

### Notes for reviewer

- Organizer URL assumed `https://gug.cz` based on the existing "GUG.cz, z.s." brand string. If the canonical org URL differs (e.g. a different landing page), update the href in `src/components/Footer.astro`.
- No content changes outside the footer; build verified locally (`npm run build` clean).

## Verification

- `npm run build` — passes, 4 pages built
- Visually checked layout breakpoints at 1200 / 800 / 400 px

🤖 Generated with [Claude Code](https://claude.com/claude-code)