### PR TITLE
fix(footer): center column titles on mobile

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -178,6 +178,10 @@ const SITEMAP = [
 		flex-direction: column;
 		gap: 1.2rem;
 		min-width: 0;
+
+		@media (max-width: 500px) {
+			align-items: center;
+		}
 	}
 
 	.col-title {


### PR DESCRIPTION
## Summary

Center footer column titles (SITEMAP, EVENT, ORGANIZER) on mobile viewports under 500px. Previously they sat flush-left while the rest of the column content was centered, breaking the layout's symmetry.

## Why

`.col` is a flex container with `flex-direction: column` and the default `align-items: stretch`. `.col-title` is declared as `display: inline-flex` but flex children get blockified, so it stretched to the full column width. With `justify-content: normal` (= flex-start) on the title, the text and decorative line collapsed to the left edge of each column.

The brand and sitemap columns happened to look fine because their column width was driven by short text (`max-width: 32ch` tagline / link labels), but the event column was sized by the wider `dl` and the organizer column by the social icon row, so their titles drifted noticeably left.

## Fix

Add `align-items: center` to `.col` inside the `@media (max-width: 500px)` block so children shrink to content width and align with the already-centered grid. No other markup or styles changed.

## Verification

- Visual check at 320px and 375px viewports — all three section titles centered, decorative line trails to the right of the text consistently.