### PR TITLE
copy(home): broaden gallery title to span past editions

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -68,13 +68,13 @@ const tickerTopics = [
 		<Tickets client:visible />
 		-->
 
-		<!-- GALLERY — photos from last year's edition -->
+		<!-- GALLERY — photos from past editions -->
 		<section id="gallery" aria-labelledby="gallery-title">
 			<div class="gallery-head">
 				<div class="section-label">From the archives</div>
-				<h2 id="gallery-title" class="section-title">DevFest <span class="red">2025</span></h2>
+				<h2 id="gallery-title" class="section-title">Past <span class="red">DevFests</span></h2>
 				<p class="gallery-lede">
-					Last year's case is closed. A look back at the people who cracked it with us.
+					Cases closed, files reopened. A look back at the people who cracked them with us.
 				</p>
 			</div>
 


### PR DESCRIPTION
## Summary

- Retitle the homepage gallery from "DevFest 2025" to "Past DevFests" so it reflects photos from multiple past editions, not only last year.
- Refresh the lede to match the broader scope.
- Update the section comment in the same spirit.

## Why

Gallery is intended to cover multiple past DevFest editions, but the existing copy (title + lede + comment) framed it as a recap of a single previous year.

## Files

- `src/pages/index.astro` — gallery title, lede, and surrounding comment.