### PR TITLE
feat(menu): hide nav logo on home hero

### DIFF
--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -6,13 +6,14 @@ const links = [
 ] as const;
 
 const currentPath = Astro.url.pathname.replace(/\/$/, '') || '/';
+const isHome = currentPath === '/';
 const isCurrent = (href: string) => {
 	const path = href.split('#')[0].replace(/\/$/, '') || '/';
 	return !href.startsWith('http') && path === currentPath;
 };
 ---
 
-<header id="site-header" class="site-header" data-state="top">
+<header id="site-header" class="site-header" data-state="top" data-home={isHome ? 'true' : 'false'}>
 	<a href="/" class="brand" aria-label="DevFest.cz 2026 — home">
 		<img src="/logo.svg" alt="DevFest.cz 2026" class="brand-logo" width="210" height="42" />
 	</a>
@@ -151,13 +152,21 @@ const isCurrent = (href: string) => {
 		color: var(--color-text);
 		flex-shrink: 0;
 		filter: drop-shadow(0 2px 10px rgba(0, 0, 0, 0.85));
-		transition: opacity 0.2s, transform 0.2s;
+		transition: opacity 0.25s ease, transform 0.2s;
 	}
 
 	.brand:hover,
 	.brand:focus-visible {
 		opacity: 0.85;
 		outline: none;
+	}
+
+	// Home + at top: hero owns brand identity, hide nav logo to avoid duplication.
+	// visibility: hidden keeps the flex slot so nav doesn't jump left on state flip.
+	.site-header[data-home='true'][data-state='top'] .brand {
+		opacity: 0;
+		visibility: hidden;
+		pointer-events: none;
 	}
 
 	.brand-logo {


### PR DESCRIPTION
## Summary
- Hide the `.brand` logo in the fixed top nav when on `/` AND scroll state is `top`.
- Logo fades back in as soon as the user scrolls (existing `data-state="scrolled"` flip), and stays visible on all non-home routes.

## Why
The home hero already establishes the DevFest.cz 2026 brand, so the menu logo doubled up at the top of the page. Removing it cleans up the first impression without losing wayfinding once the hero scrolls off.

## Behavior
- New `data-home` attribute on `#site-header` (`"true"` on `/`, `"false"` elsewhere).
- New CSS rule: `.site-header[data-home='true'][data-state='top'] .brand` → `opacity: 0; visibility: hidden; pointer-events: none`.
- `visibility: hidden` (not `display: none`) preserves the flex slot so the nav doesn't shift horizontally when scroll state flips.
- Opacity transition piggybacks on the existing `.brand` transition for a smooth fade.

## Files
- `src/components/Menu.astro` — frontmatter `isHome` flag, `data-home` attribute on header, conditional CSS rule.