### PR TITLE
fix(layout): set html bg to match theme-color (mobile URL bar tint)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -148,6 +148,9 @@ const jsonLd = JSON.stringify([
 		scroll-behavior: smooth;
 		// keep keyboard-focused elements clear of the fixed cookie banner
 		scroll-padding-bottom: 8rem;
+		// canvas color — backs the iOS Safari URL bar tint and prevents
+		// a white flash during rubber-band scroll past the body edges.
+		background: var(--color-bg);
 	}
 
 	@media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- Add `background: var(--color-bg)` to the root `html` rule in `BaseLayout.astro` so the canvas under the body matches `#050505`.

## Why
Mobile browsers — iOS Safari especially — sample the canvas behind the URL bar. With only `body` carrying a background, the html canvas stayed transparent and the URL bar tint fell back to white during rubber-band scroll or in safe-area gaps, even though `<meta name="theme-color" content="#050505">` is set. Matching the html bg keeps the tint solid black across scroll states.

## Behavior
- Desktop: no visible change (html was visually covered by body bg already).
- Mobile: URL bar tint stays `#050505` at the top of every page, no white flash on overscroll.

## Files
- `src/layouts/BaseLayout.astro`

🤖 Generated with [Claude Code](https://claude.com/claude-code)