### PR TITLE
copy(home): rewrite hero tagline for clearer English

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,7 +31,7 @@ const tickerTopics = [
 					</h1>
 
 					<p class="hero-subtitle">
-						The most original conference in Prague is here again—and it&rsquo;s not without a few mysteries.
+						Prague&rsquo;s most original conference is back—and it&rsquo;s brought a few mysteries with it.
 					</p>
 
 					<div class="hero-meta">


### PR DESCRIPTION
## Summary

Rewrites the hero tagline on the homepage so it reads naturally.

- Before: *"The most original conference in Prague is here again—and it's not without a few mysteries."*
- After: *"Prague's most original conference is back—and it's brought a few mysteries with it."*

## Why

The original phrasing had two rough edges:
- "is here again" reads stilted; "is back" is the idiomatic equivalent.
- "it's not without a few mysteries" is a double negative that takes a beat to parse.

The new copy keeps the noir/detective tone (carried by the gallery + newsletter copy) while reading as natural English.

## Files

- `src/pages/index.astro` — single-line copy change on the `.hero-subtitle` paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)