### PR TITLE
style(footer): remove red accent stripe above top border

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -132,17 +132,6 @@ const SITEMAP = [
 		font-family: 'Share Tech Mono', monospace;
 		color: rgba(240, 237, 230, 0.65);
 
-		&::before {
-			content: '';
-			position: absolute;
-			top: -1px;
-			left: 50%;
-			transform: translateX(-50%);
-			width: 60px;
-			height: 1px;
-			background: rgba(204, 0, 0, 0.4);
-		}
-
 		@media (max-width: 700px) {
 			padding: 3.5rem 1.5rem 2rem;
 		}


### PR DESCRIPTION
## Summary

- Drop the 60px red `::before` line at the footer's top edge.
- Neutral top border now reads as a clean section divider.

## Why

The red accent stripe drew the eye to the footer seam without earning the emphasis. Removing it lets the footer recede and matches the understated chrome elsewhere in the layout.

## Behavior

- Visual only — no markup or behavior changes.
- `position: relative` + `z-index: 2` retained on `.footer` for stacking against the scanline overlay.

## Files

- `src/components/Footer.astro` — remove `.footer::before` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)