### PR TITLE
style(footer): flank column titles with accent lines on both sides

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -185,11 +185,19 @@ const SITEMAP = [
 		align-items: center;
 		gap: 0.6rem;
 
+		&::before,
 		&::after {
 			content: '';
 			flex: 0 0 28px;
 			height: 1px;
 			background: rgba(204, 0, 0, 0.35);
+		}
+
+		@media (max-width: 500px) {
+			&::before,
+			&::after {
+				flex-basis: 20px;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Mirror the red accent rule on footer column titles so it frames each label on both sides instead of trailing off only to the right.
- Shorten the rule segments to 20px on narrow viewports (≤500px) to keep the centered mobile layout balanced.

## Why

Single right-side rule read as unfinished; symmetric flanking matches the surrounding monospace/typewriter aesthetic and reads as intentional.

## Behavior

- Desktop / tablet: each footer column title (`DEVFEST.CZ 2026`, `SITEMAP`, `EVENT`, `ORGANIZER`) now has a 28px accent rule on both sides.
- Mobile (≤500px): rules shrink to 20px each so the centered title fits without crowding.

## Files

- `src/components/Footer.astro` — extend `.col-title::after` rule to `::before, ::after`; add ≤500px media query for narrower flanks.