### PR TITLE
feat(menu): animate nav logo show/hide on home

### DIFF
--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -152,7 +152,13 @@ const isCurrent = (href: string) => {
 		color: var(--color-text);
 		flex-shrink: 0;
 		filter: drop-shadow(0 2px 10px rgba(0, 0, 0, 0.85));
-		transition: opacity 0.25s ease, transform 0.2s;
+		opacity: 1;
+		transform: translateY(0);
+		// Reveal/hide: fade + slide; visibility delay handled per-state.
+		transition:
+			opacity 0.4s ease,
+			transform 0.4s ease,
+			visibility 0s linear 0s;
 	}
 
 	.brand:hover,
@@ -167,6 +173,12 @@ const isCurrent = (href: string) => {
 		opacity: 0;
 		visibility: hidden;
 		pointer-events: none;
+		transform: translateY(-6px);
+		// Delay visibility flip until after opacity fade-out so transition stays smooth.
+		transition:
+			opacity 0.4s ease,
+			transform 0.4s ease,
+			visibility 0s linear 0.4s;
 	}
 
 	.brand-logo {
@@ -380,8 +392,10 @@ const isCurrent = (href: string) => {
 		.nav-link,
 		.nav-link--cta,
 		.brand,
+		.site-header[data-home='true'][data-state='top'] .brand,
 		.nav-toggle-bars span {
 			transition: none;
+			transform: none;
 		}
 	}
 </style>


### PR DESCRIPTION
## Summary
- Replace instant `visibility: hidden` snap with a 0.4s opacity + `translateY(-6px)` glide on the nav `.brand`
- Delay the `visibility` flip until after the opacity fade-out so the flex slot stays reserved without cutting motion short
- Extend the `prefers-reduced-motion` block to cover the state-specific selector so motion-sensitive users keep the instant swap

## Why
The nav logo was snapping in/out the moment the header crossed `data-state='top'` ↔ `'scrolled'`. The hero already animates as you scroll, so a hard cut here read as a glitch. A short fade + slide makes the handoff between hero logo and nav logo feel intentional.

## Behavior
- Home + at top: logo slot reserved, logo invisible (offset -6px)
- Home + scrolled / any other page: logo eased in to opacity 1, `translateY(0)`
- Reduced-motion: no transition, no transform — instant state swap (existing UX preserved)

## Files
- `src/components/Menu.astro`