### PR TITLE
feat(seo): expand Event JSON-LD per Google guidance

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -60,7 +60,7 @@ const eventSchema = {
 	},
 	"organizer": {
 		"@type": "Organization",
-		"name": "GDG Czech Republic (GUG.cz, z.s.)",
+		"name": "GUG.cz, z.s.",
 		"url": "https://gug.cz"
 	}
 };

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -21,40 +21,75 @@ const ogImage = `${siteUrl}/og-image.jpg`;
 const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
 const ogImageAlt = "DevFest.cz 2026 conference banner";
 
-const jsonLd = JSON.stringify([
-	{
-		"@context": "https://schema.org",
-		"@type": "Event",
-		"name": title,
-		"description": description,
-		"image": ogImage,
-		"eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-		"eventStatus": "https://schema.org/EventScheduled",
-		"startDate": "2026-10-30T09:00:00+01:00",
-		"endDate": "2026-10-30T20:00:00+01:00",
-		"inLanguage": "en",
-		"location": {
-			"@type": "Place",
-			"name": "Prague",
-			"address": {
-				"@type": "PostalAddress",
-				"addressLocality": "Prague",
-				"addressCountry": "CZ"
-			}
-		},
-		"organizer": {
-			"@type": "Organization",
-			"name": "GDG Czech Republic",
-			"url": siteUrl
+// Event schema follows https://developers.google.com/search/docs/appearance/structured-data/event
+// Only rendered on the home page so subpages (privacy, contact, etc.) don't
+// claim to BE the event. WebSite + Organization render sitewide.
+const isHome = Astro.url.pathname === "/";
+
+// Once ti.to release is public, add `offers` to the Event:
+// "offers": {
+//   "@type": "Offer",
+//   "url": "https://ti.to/<account>/<event>",
+//   "price": "0",
+//   "priceCurrency": "CZK",
+//   "availability": "https://schema.org/InStock",
+//   "validFrom": "2026-XX-XXT00:00:00+02:00"
+// }
+const eventSchema = {
+	"@context": "https://schema.org",
+	"@type": "Event",
+	"name": "DevFest.cz 2026",
+	"description":
+		"DevFest.cz 2026 — Prague's developer conference & festival. Web, Mobile, Cybersecurity, AI/ML.",
+	"image": [ogImage],
+	"url": siteUrl,
+	"startDate": "2026-10-30T09:00:00+01:00",
+	"endDate": "2026-10-30T20:00:00+01:00",
+	"eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+	"eventStatus": "https://schema.org/EventScheduled",
+	"inLanguage": "en",
+	"location": {
+		"@type": "Place",
+		"name": "Prague",
+		"address": {
+			"@type": "PostalAddress",
+			"addressLocality": "Prague",
+			"addressRegion": "Prague",
+			"addressCountry": "CZ"
 		}
 	},
-	{
-		"@context": "https://schema.org",
-		"@type": "WebSite",
-		"name": "DevFest.cz",
-		"url": siteUrl
+	"organizer": {
+		"@type": "Organization",
+		"name": "GDG Czech Republic (GUG.cz, z.s.)",
+		"url": "https://gug.cz"
 	}
-]);
+};
+
+const organizationSchema = {
+	"@context": "https://schema.org",
+	"@type": "Organization",
+	"name": "DevFest.cz",
+	"url": siteUrl,
+	"logo": `${siteUrl}/logo.png`,
+	"sameAs": [
+		"https://x.com/devfest_cz",
+		"https://www.facebook.com/DevFestCZ",
+		"https://bsky.app/profile/devfest.cz"
+	]
+};
+
+const websiteSchema = {
+	"@context": "https://schema.org",
+	"@type": "WebSite",
+	"name": "DevFest.cz",
+	"url": siteUrl
+};
+
+const jsonLd = JSON.stringify(
+	isHome
+		? [eventSchema, organizationSchema, websiteSchema]
+		: [organizationSchema, websiteSchema]
+);
 ---
 
 <html lang="en">


### PR DESCRIPTION
## Summary

Aligns the homepage structured data with Google's [Event rich result guidance](https://developers.google.com/search/docs/appearance/structured-data/event).

## Why

The previous `Event` block was minimal and rendered on every page — meaning `/privacy-policy`, `/contact`, and `/partners` all claimed to BE the conference. It also passed the page `title` / `description` into `Event.name` / `Event.description`, so subpage titles were leaking into the event entity.

## Behavior

- `Event` JSON-LD now only emits on `/` (the actual event landing page).
- `Event.name` is hard-coded to `DevFest.cz 2026` instead of mirroring the page title.
- `image` is now an array (Google recommends multiple aspect ratios — currently one entry, room to add more later).
- `url` added on the Event itself.
- `PostalAddress` filled out with `addressRegion` in addition to locality + country.
- `organizer` now points at the real legal entity: `GDG Czech Republic (GUG.cz, z.s.)` → https://gug.cz, matching the footer.
- New sitewide `Organization` schema with `logo` and `sameAs` (X / Facebook / Bluesky — the three DevFest-specific profiles).
- `WebSite` schema kept sitewide.
- Inline TODO in the source shows the exact `offers` block to add when the ti.to release goes public — Google requires `url`, `price`, `priceCurrency`, `availability`, `validFrom`, so it's left out for now rather than shipping a dishonest `price: 0`.

## Files

- `src/layouts/BaseLayout.astro`

## Verification

- `npm run build` clean — all 6 pages emit.
- Confirmed `/index.html` contains Event + Organization + WebSite.
- Confirmed `/privacy-policy/`, `/contact/`, `/partners/` contain Organization + WebSite only (no Event).
- After deploy, paste `https://devfest.cz` into [Google Rich Results Test](https://search.google.com/test/rich-results); expect Event detected with warnings for `offers` / `performer` (recommended, not required).