### PR TITLE
feat(functions): list purchased tickets in titoWebhook Slack post

### DIFF
--- a/functions/src/tickets/notify-purchase.ts
+++ b/functions/src/tickets/notify-purchase.ts
@@ -43,6 +43,20 @@ function formatPrice(price: string | null | undefined, currency: string | null |
 	}
 }
 
+function summarizeTickets(tickets: TitoWebhookPayload[] | undefined): string | null {
+	if (!tickets || tickets.length === 0) return null;
+	const counts = new Map<string, number>();
+	for (const ticket of tickets) {
+		const title = ticket.release_title?.trim() || 'Unknown release';
+		counts.set(title, (counts.get(title) ?? 0) + 1);
+	}
+	const lines: string[] = [];
+	for (const [title, count] of counts) {
+		lines.push(count > 1 ? `• ${count}× ${title}` : `• ${title}`);
+	}
+	return lines.join('\n');
+}
+
 function buildSlackMessage(event: TitoWebhookEvent, payload: TitoWebhookPayload): SlackPayload {
 	const isRegistration = event.startsWith('registration.');
 
@@ -58,7 +72,12 @@ function buildSlackMessage(event: TitoWebhookEvent, payload: TitoWebhookPayload)
 
 	if (payload.email) fields.push({ type: 'mrkdwn', text: `*Email:*\n${payload.email}` });
 
-	if (!isRegistration && payload.release_title) {
+	if (isRegistration) {
+		const ticketSummary = summarizeTickets(payload.tickets);
+		if (ticketSummary) {
+			fields.push({ type: 'mrkdwn', text: `*Tickets:*\n${ticketSummary}` });
+		}
+	} else if (payload.release_title) {
 		fields.push({ type: 'mrkdwn', text: `*Release:*\n${payload.release_title}` });
 	}
 


### PR DESCRIPTION
## Summary
- Registration webhook events now include a `*Tickets:*` field in the Slack post that lists each `release_title` from `payload.tickets`, grouped with counts (e.g. `2× Early Bird`, `1× Student`).
- New `summarizeTickets()` helper in [notify-purchase.ts](functions/src/tickets/notify-purchase.ts) builds the bullet list.
- `ticket.completed` events are unchanged — they already surface the release in the headline and `*Release:*` field.

## Why
Previously the Slack notification for `registration.finished` only said "Registration finished — N ticket(s)" with no indication of *which* tiers were bought. Organisers had to open ti.to to find out. Now the post itself answers it.

## Behavior
- `registration.finished` with one Early Bird and one Student → field shows:
  ```
  • Early Bird
  • Student
  ```
- `registration.finished` with two Early Bird → `• 2× Early Bird`.
- Missing/empty `release_title` falls back to `Unknown release`.

## Files
- `functions/src/tickets/notify-purchase.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)