### PR TITLE
fix(nav): pin nav behind iOS status bar + hide-on-scroll on mobile

### DIFF
--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -74,13 +74,75 @@ const isCurrent = (href: string) => {
 	const toggle = document.getElementById('nav-toggle');
 	const list = document.getElementById('nav-list');
 
-	// Scroll state — switches transparent → solid blurred backdrop
-	const onScroll = () => {
+	// Scroll state — sets data-state for brand reveal on home page
+	const onScrollState = () => {
 		if (!header) return;
 		header.dataset.state = window.scrollY > 24 ? 'scrolled' : 'top';
 	};
-	onScroll();
-	window.addEventListener('scroll', onScroll, { passive: true });
+	onScrollState();
+	window.addEventListener('scroll', onScrollState, { passive: true });
+
+	// Hide-on-scroll-down, show-on-scroll-up — matches verygood.ventures
+	// pattern. Avoids the "partial shrink" look on Chrome mobile where the
+	// browser URL bar collapses gradually; instead nav fully slides out of
+	// view, lining up with the disappearing browser chrome.
+	let lastY = 0;
+	let delta = 0;
+	let hidden = false;
+	let raf = false;
+	const HIDE_THRESHOLD = 10;
+	const MIN_SCROLL_Y = 80;
+	// Only auto-hide on touch / small-viewport devices — on desktop the
+	// fixed nav stays visible so the user can jump sections without scroll-up.
+	const hideMql = window.matchMedia('(max-width: 760px)');
+	// Safari (macOS + iOS) collapses its own URL bar on scroll — stacking a
+	// second hide animation on top looks broken, so skip auto-hide there.
+	// Match `Safari` UA token while excluding the Chromium-family browsers
+	// that also include `Safari` in their string (Chrome, Edge, Firefox iOS).
+	const ua = navigator.userAgent;
+	const isSafari = /Safari/.test(ua) && !/(Chrome|CriOS|FxiOS|EdgiOS|Edg\/|Android)/.test(ua);
+	const onScrollHide = () => {
+		const y = window.scrollY;
+		if (header) {
+			const diff = y - lastY;
+			delta += diff;
+			// Reset direction accumulator when scroll direction flips so the
+			// next gesture isn't fighting leftover delta from the previous one.
+			if ((diff > 0 && delta < 0) || (diff < 0 && delta > 0)) delta = diff;
+			// Don't hide while the drawer is open — the user needs the toggle.
+			const drawerOpen = toggle?.getAttribute('aria-expanded') === 'true';
+			const canHide = hideMql.matches && !isSafari;
+			if (canHide && delta > HIDE_THRESHOLD && y > MIN_SCROLL_Y && !hidden && !drawerOpen) {
+				header.dataset.hidden = 'true';
+				hidden = true;
+				delta = 0;
+			} else if ((!canHide || delta < -HIDE_THRESHOLD) && hidden) {
+				header.dataset.hidden = 'false';
+				hidden = false;
+				delta = 0;
+			}
+		}
+		lastY = y;
+		raf = false;
+	};
+	// Restore visibility if user resizes from mobile → desktop while hidden.
+	hideMql.addEventListener('change', (ev) => {
+		if (!ev.matches && header && hidden) {
+			header.dataset.hidden = 'false';
+			hidden = false;
+			delta = 0;
+		}
+	});
+	window.addEventListener(
+		'scroll',
+		() => {
+			if (!raf) {
+				requestAnimationFrame(onScrollHide);
+				raf = true;
+			}
+		},
+		{ passive: true }
+	);
 
 	// Mobile drawer toggle — make non-drawer regions inert when open so
 	// keyboard focus and AT navigation stay within the menu.
@@ -93,6 +155,12 @@ const isCurrent = (href: string) => {
 		toggle.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
 		list.dataset.open = String(open);
 		document.body.style.overflow = open ? 'hidden' : '';
+		// Force header visible when the drawer opens — user needs the toggle.
+		if (open && header) {
+			header.dataset.hidden = 'false';
+			hidden = false;
+			delta = 0;
+		}
 		for (const el of inertTargets()) {
 			if (open) {
 				el.setAttribute('inert', '');
@@ -141,27 +209,37 @@ const isCurrent = (href: string) => {
 		gap: 1.5rem;
 		// Constant padding — height stays fixed across scroll states so
 		// nav doesn't reflow / jump when the scroll handler flips data-state.
-		// `padding-top` extends into the safe-area inset so iOS in-app
-		// browsers (Discord, Instagram, etc.) and notched devices don't show
-		// scrolled page content through translucent browser chrome.
-		padding: max(0.75rem, env(safe-area-inset-top)) 3rem 0.75rem;
-		// Solid scrim at the very top so anything behind translucent browser
-		// chrome reads as the brand background, fading to transparent further
-		// down so the hero photo still bleeds into nav at rest.
-		background: linear-gradient(
-			to bottom,
-			rgba(5, 5, 5, 1) 0%,
-			rgba(5, 5, 5, 1) 40%,
-			rgba(5, 5, 5, 0.55) 80%,
-			rgba(5, 5, 5, 0) 100%
-		);
-		transition: background 0.25s ease, backdrop-filter 0.25s ease;
+		padding: 0.75rem 3rem;
+		// Solid opaque background across all scroll states. Matches VGV
+		// pattern — fixed nav stays readable, no gradient bleed at any
+		// scroll position, no transparent zones for page content to leak
+		// through on iOS Safari URL-bar transitions.
+		background: #050505;
+		transition: transform 0.3s ease;
 	}
 
-	.site-header[data-state='scrolled'] {
-		background: rgba(5, 5, 5, 1);
-		backdrop-filter: blur(12px) saturate(120%);
-		-webkit-backdrop-filter: blur(12px) saturate(120%);
+	// Extends the header background upward by safe-area-inset-top so the
+	// brand-dark scrim fills the area behind the iOS / iPadOS status bar
+	// without pushing nav content below it via padding.
+	.site-header::before {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: calc(-1 * env(safe-area-inset-top));
+		height: env(safe-area-inset-top);
+		background: #050505;
+		pointer-events: none;
+	}
+
+	// Hide-on-scroll-down: full slide-up so nav doesn't look "shrunk" while
+	// the browser URL bar collapses next to it. JS sets data-hidden=true.
+	// Transform only applied in the hidden state — keeping the resting nav
+	// transform-free lets iOS Safari extend the layout viewport behind the
+	// status bar instead of pinning the header below it.
+	.site-header[data-hidden='true'] {
+		transform: translate3d(0, -100%, 0);
+		-webkit-transform: translate3d(0, -100%, 0);
 	}
 
 	/* ===================== BRAND ===================== */

--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -82,10 +82,10 @@ const isCurrent = (href: string) => {
 	onScrollState();
 	window.addEventListener('scroll', onScrollState, { passive: true });
 
-	// Hide-on-scroll-down, show-on-scroll-up — matches verygood.ventures
-	// pattern. Avoids the "partial shrink" look on Chrome mobile where the
-	// browser URL bar collapses gradually; instead nav fully slides out of
-	// view, lining up with the disappearing browser chrome.
+	// Hide-on-scroll-down, show-on-scroll-up. Avoids the "partial shrink"
+	// look on Chrome mobile where the browser URL bar collapses gradually;
+	// instead nav fully slides out of view, lining up with the disappearing
+	// browser chrome.
 	let lastY = 0;
 	let delta = 0;
 	let hidden = false;
@@ -210,10 +210,10 @@ const isCurrent = (href: string) => {
 		// Constant padding — height stays fixed across scroll states so
 		// nav doesn't reflow / jump when the scroll handler flips data-state.
 		padding: 0.75rem 3rem;
-		// Solid opaque background across all scroll states. Matches VGV
-		// pattern — fixed nav stays readable, no gradient bleed at any
-		// scroll position, no transparent zones for page content to leak
-		// through on iOS Safari URL-bar transitions.
+		// Solid opaque background across all scroll states — fixed nav
+		// stays readable, no gradient bleed at any scroll position, no
+		// transparent zones for page content to leak through on iOS
+		// Safari URL-bar transitions.
 		background: #050505;
 		transition: transform 0.3s ease;
 	}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -225,11 +225,10 @@ const jsonLd = JSON.stringify(
 	}
 
 	body {
-		// `100vh` (not `100dvh`) matches VGV — dynamic viewport units reflow
-		// the body box when iOS Safari's URL bar collapses, which can shift
-		// where the layout viewport's top edge sits and cause `position:
-		// fixed; top: 0` to render below the system status bar instead of
-		// behind it.
+		// `100vh` (not `100dvh`) — dynamic viewport units reflow the body
+		// box when iOS Safari's URL bar collapses, which can shift where
+		// the layout viewport's top edge sits and cause `position: fixed;
+		// top: 0` to render below the system status bar instead of behind it.
 		min-height: 100vh;
 		display: flex;
 		flex-direction: column;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -100,12 +100,7 @@ const jsonLd = JSON.stringify(
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<meta name="generator" content={Astro.generator} />
-		<meta name="theme-color" content="#050505" />
-		<meta name="theme-color" content="#050505" media="(prefers-color-scheme: light)" />
-		<meta name="theme-color" content="#050505" media="(prefers-color-scheme: dark)" />
 		<meta name="color-scheme" content="dark" />
-		<meta name="apple-mobile-web-app-capable" content="yes" />
-		<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 		<meta name="robots" content={noindex ? "noindex, nofollow" : "index, follow"} />
 
 		<title>{title}</title>
@@ -197,6 +192,14 @@ const jsonLd = JSON.stringify(
 		// canvas color — backs the iOS Safari URL bar tint and prevents
 		// a white flash during rubber-band scroll past the body edges.
 		background: var(--color-bg);
+		// Horizontal overflow clipped at the html level (not body) — keeps
+		// body free of overflow rules, which on iOS Safari can otherwise
+		// turn body into the scroll container and anchor `position: fixed`
+		// to body rather than the layout viewport.
+		overflow-x: hidden;
+		@supports (overflow-x: clip) {
+			overflow-x: clip;
+		}
 	}
 
 	@media (prefers-reduced-motion: reduce) {
@@ -222,7 +225,12 @@ const jsonLd = JSON.stringify(
 	}
 
 	body {
-		min-height: 100dvh;
+		// `100vh` (not `100dvh`) matches VGV — dynamic viewport units reflow
+		// the body box when iOS Safari's URL bar collapses, which can shift
+		// where the layout viewport's top edge sits and cause `position:
+		// fixed; top: 0` to render below the system status bar instead of
+		// behind it.
+		min-height: 100vh;
 		display: flex;
 		flex-direction: column;
 		background: var(--color-bg);
@@ -230,7 +238,6 @@ const jsonLd = JSON.stringify(
 		font-family: 'Special Elite', cursive;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
-		overflow-x: hidden;
 
 		// Opt-out so terminal pages (404, post-submit) can render plain text
 		// against solid bg — axe-core sometimes mis-samples through blend overlays.


### PR DESCRIPTION
## Summary

- Make the fixed site header sit **behind** the iOS Safari status bar instead of below it.
- Force a solid `#050505` background at every scroll state — no more transparent gradient zones leaking page content through during iOS URL-bar transitions.
- Add a hide-on-scroll-down / show-on-scroll-up behaviour on **Chrome mobile only** so the nav doesn't appear to "partially shrink" while the browser URL bar collapses next to it.

## Why

The nav previously rendered visually *under* the iOS status bar with a gap between them. Investigation found a stack of CSS interactions on the layout / body that were silently breaking `position: fixed; top: 0`:

| Problem | Fix |
| --- | --- |
| `overflow-x: hidden` on body turned body into the iOS Safari scroll container; fixed elements anchored to the body box instead of the layout viewport. | Moved to `html`, with an `@supports` fallback to `overflow-x: clip` so the rule doesn't promote html to a scroll container either. |
| `min-height: 100dvh` reflowed the body box when Safari's URL bar collapsed, shifting where the layout viewport's top edge landed. | `min-height: 100vh`. |
| `theme-color` + `apple-mobile-web-app-*` meta tags painted an opaque dark band *above* the webview on some iOS Safari versions, pushing our `top: 0` header below it. | Removed — the page bg is already `#050505`, so the system chrome's default behaviour already looks right. |
| Header gradient faded to transparent at the bottom — page content leaked through during URL-bar transitions. | Solid `#050505` always. Added a `::before` slab that paints `env(safe-area-inset-top)` of bg *above* the header so the status-bar region stays backed by the brand colour without padding the nav content. |

## Behavior

- **iOS Safari (mobile)**: nav now extends behind the status bar (its dark bg fills that region). Nav doesn't auto-hide on scroll — Safari already collapses its own URL bar, so stacking a second animation looked broken.
- **Chrome mobile**: nav fully slides out on scroll-down (after 80px) and slides back in on scroll-up of 10px+. Drawer open forces nav visible.
- **Desktop (≥ 761px)**: nav stays fixed at top at all times. Hide-on-scroll only triggers on mobile-sized viewports.

## Files

- `src/components/Menu.astro` — solid bg, `::before` safe-area slab, hide-on-scroll JS gated by `max-width: 760px` and non-Safari UA.
- `src/layouts/BaseLayout.astro` — `overflow-x` moved to `html`, `min-height: 100vh`, dropped `theme-color` and `apple-mobile-web-app-*` metas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)