### PR TITLE
fix(nav): paint status-bar zone behind iOS Safari translucent chrome

### DIFF
--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -202,7 +202,10 @@ const isCurrent = (href: string) => {
 		top: 0;
 		left: 0;
 		right: 0;
-		z-index: 100;
+		// Sits above the .status-bar-cover (z=10000) and the film-grain
+		// / scanline body overlays so nav content stays opaque across
+		// the full stacking order.
+		z-index: 10001;
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
@@ -216,20 +219,6 @@ const isCurrent = (href: string) => {
 		// Safari URL-bar transitions.
 		background: #050505;
 		transition: transform 0.3s ease;
-	}
-
-	// Extends the header background upward by safe-area-inset-top so the
-	// brand-dark scrim fills the area behind the iOS / iPadOS status bar
-	// without pushing nav content below it via padding.
-	.site-header::before {
-		content: '';
-		position: absolute;
-		left: 0;
-		right: 0;
-		top: calc(-1 * env(safe-area-inset-top));
-		height: env(safe-area-inset-top);
-		background: #050505;
-		pointer-events: none;
 	}
 
 	// Hide-on-scroll-down: full slide-up so nav doesn't look "shrunk" while

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -100,6 +100,16 @@ const jsonLd = JSON.stringify(
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<meta name="generator" content={Astro.generator} />
+		<!--
+			theme-color: tints iOS Safari's status bar / URL bar so the
+			native chrome stays brand-dark even when the layout viewport
+			doesn't extend behind it. Variants for light + dark cover
+			browsers that only respect the media-scoped form (Firefox,
+			Samsung Internet, older iOS in-app browsers).
+		-->
+		<meta name="theme-color" content="#050505" />
+		<meta name="theme-color" content="#050505" media="(prefers-color-scheme: light)" />
+		<meta name="theme-color" content="#050505" media="(prefers-color-scheme: dark)" />
 		<meta name="color-scheme" content="dark" />
 		<meta name="robots" content={noindex ? "noindex, nofollow" : "index, follow"} />
 
@@ -151,6 +161,16 @@ const jsonLd = JSON.stringify(
 	</head>
 	<body class={bodyClass}>
 		<a href="#main-content" class="skip-link">Skip to main content</a>
+		<!--
+			Status-bar scrim — paints brand-dark behind iOS Safari's
+			translucent status bar / notch zone. Uses the
+			`top: calc(-1 * env(safe-area-inset-top))` trick so the
+			cover extends UP into the safe-area inset even when Safari
+			ignores `viewport-fit=cover` and anchors `top:0` below the
+			safe area. Z-index sits above the film-grain + scanline
+			overlays (9999 / 9998) so it stays opaque under the chrome.
+		-->
+		<div class="status-bar-cover" aria-hidden="true"></div>
 		<Menu />
 		<div id="main-content"><slot /></div>
 		<CookieBanner />
@@ -192,11 +212,16 @@ const jsonLd = JSON.stringify(
 		// canvas color — backs the iOS Safari URL bar tint and prevents
 		// a white flash during rubber-band scroll past the body edges.
 		background: var(--color-bg);
-		// Horizontal overflow clipped at the html level (not body) — keeps
-		// body free of overflow rules, which on iOS Safari can otherwise
-		// turn body into the scroll container and anchor `position: fixed`
-		// to body rather than the layout viewport.
-		overflow-x: hidden;
+		// Horizontal overflow clipped via `overflow-x: clip` only — NOT
+		// `overflow-x: hidden`. `hidden` turns html into a scroll
+		// container on iOS Safari, which anchors `position: fixed`
+		// elements to the html box instead of the layout viewport
+		// (so fixed top:0 lands below the iOS status bar / notch and
+		// `env(safe-area-inset-top)` reports 0). `clip` (Safari 15.4+)
+		// hides overflow without becoming a scroll container, leaving
+		// viewport-fit=cover + env() working as specced. On older
+		// browsers without `clip` support we accept potential horizontal
+		// overflow rather than break top-chrome rendering.
 		@supports (overflow-x: clip) {
 			overflow-x: clip;
 		}
@@ -325,5 +350,27 @@ const jsonLd = JSON.stringify(
 	@keyframes ticker {
 		from { transform: translateX(0); }
 		to { transform: translateX(-50%); }
+	}
+
+	// Status-bar scrim. iOS Safari ignores `viewport-fit=cover` in some
+	// browser modes and anchors `position: fixed; top: 0` *below* the
+	// safe-area inset, leaving the area behind the translucent status
+	// bar showing scrolled page content. Pulling the cover UP by
+	// `env(safe-area-inset-top)` with matching height paints exactly
+	// the inset zone — never overlaps the nav header below. Confirmed
+	// on iPhone Pro (Dynamic Island).
+	//
+	// `z-index: 10000` sits above the film-grain (9999) and scanline
+	// (9998) body overlays so mix-blend-mode doesn't desaturate / hide
+	// the cover. On desktop env == 0 → zero-height cover → invisible.
+	.status-bar-cover {
+		position: fixed;
+		top: calc(-1 * env(safe-area-inset-top));
+		left: 0;
+		right: 0;
+		height: env(safe-area-inset-top);
+		background: var(--color-bg);
+		z-index: 10000;
+		pointer-events: none;
 	}
 </style>


### PR DESCRIPTION
## Summary

The fixed nav header was leaving the area behind iOS Safari's translucent status bar / Dynamic Island showing scrolled page content in browser modes where `viewport-fit=cover` is not honored and `position: fixed; top: 0` is auto-insetted below the safe area. This PR paints that zone with the brand-dark color and removes the CSS that was causing the inset bug from #174.

## Why

#174 added a `.site-header::before` slab using `position: absolute` + `top: calc(-1 * env(safe-area-inset-top))` to extend the nav background upward behind the iOS status bar. It worked on devices where `viewport-fit=cover` was honored, but on the same `html { overflow-x: hidden }` rule that PR introduced as a fallback, iOS Safari turns `html` into a scroll container — which anchors `position: fixed` elements to the html box (below the safe area) instead of the layout viewport. The slab then sat at the bottom of an inset header, not behind the chrome, and `env(safe-area-inset-top)` reported `0`.

## Behavior

- **iPhone with Dynamic Island / notch:** the status bar zone is now solid `#050505`, identical to the nav background. Scrolled page content no longer bleeds through.
- **iPhone without notch / iPad / Android:** unchanged. `env(safe-area-inset-top)` resolves to `0`, the cover has zero height, and `theme-color` tints native chrome as before.
- **Desktop:** unchanged. Cover collapses to zero size.
- **In-app browsers (Discord, Instagram WebViews):** `theme-color` meta backs the chrome where supported; cover backs the rest where `env()` is exposed.

## Files

- `src/layouts/BaseLayout.astro` — add `.status-bar-cover` element + CSS, restore `theme-color` meta variants, drop `overflow-x: hidden` fallback on `html` (keep `@supports (overflow-x: clip)` only).
- `src/components/Menu.astro` — bump `.site-header` to `z-index: 10001` so nav content stays above the cover and body overlays. Remove the now-redundant `.site-header::before` safe-area slab.

## Verification

- Built with `npm run build` (clean, 7 pages).
- Empirically validated on iPhone Pro (Dynamic Island) via debug probe stack — the `top: calc(-1 * env)` + matching-height technique was the only one that reached behind the chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)