### PR TITLE
refactor(functions): only consume registration.finished in titoWebhook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Functions exposed (region `europe-west1`):
 | Name | Trigger | Effect |
 | ---- | ------- | ------ |
 | `refreshTitoCache` | `onSchedule('every 1 hours')` | Fetch releases → write RTDB `/tickets` |
-| `titoWebhook` | `onRequest` (`invoker: 'public'`) | Verify `Tito-Signature` HMAC, post `ticket.completed` / `registration.finished` to Slack |
+| `titoWebhook` | `onRequest` (`invoker: 'public'`) | Verify `Tito-Signature` HMAC, post `registration.finished` to Slack (other events 200-acked and ignored) |
 | `weeklyTicketStatus` | `onSchedule('every monday 09:00', Europe/Prague)` | Fetch live releases from ti.to and post sales summary to Slack |
 
 Browser side: `src/components/Tickets.tsx` subscribes to `/tickets` via `firebase/database`'s `onValue`. `src/lib/tito.ts` holds browser-safe helpers (types, `filterDisplayable`, `checkoutUrl`, `formatPrice`). RTDB rules in `database.rules.json` (not wired into `firebase.json` — paste manually in console).

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The default Cloud Functions service account has the IAM needed to write RTDB; no
 Wire up the webhook in ti.to → Customize → Webhook Endpoints:
 1. Paste the deployed `titoWebhook` URL.
 2. Copy ti.to's security token into `TITO_WEBHOOK_SECRET` (Secret Manager).
-3. Subscribe at least to `ticket.completed` and `registration.finished`.
+3. Subscribe to `registration.finished` — that event fires once per completed order and already lists every ticket in the registration, so subscribing to `ticket.completed` as well would double-post.
 
 ### RTDB rules
 

--- a/functions/src/tickets/notify-purchase.ts
+++ b/functions/src/tickets/notify-purchase.ts
@@ -1,10 +1,11 @@
 /**
  * `titoWebhook` — receives ti.to webhook deliveries, verifies the HMAC
- * signature, and posts a Slack notification when a ticket is purchased.
+ * signature, and posts a Slack notification when a registration finishes.
  *
  * Configure ti.to → Customize → Webhook Endpoints with the deployed URL
  * and the same security token stored in `TITO_WEBHOOK_SECRET`. Subscribe
- * to at least `ticket.completed` and `registration.finished`.
+ * to `registration.finished` — that event fires once per completed order
+ * and already contains the full list of tickets purchased.
  */
 
 import { logger } from 'firebase-functions/v2';
@@ -23,9 +24,7 @@ import {
 
 const REGION = 'europe-west1';
 
-// Events we post to Slack. Other events are accepted (200) but ignored so
-// ti.to does not retry them.
-const NOTIFY_EVENTS = new Set<TitoWebhookEvent>(['ticket.completed', 'registration.finished']);
+const NOTIFY_EVENT: TitoWebhookEvent = 'registration.finished';
 
 function formatPrice(price: string | null | undefined, currency: string | null | undefined): string | null {
 	if (!price) return null;
@@ -57,13 +56,9 @@ function summarizeTickets(tickets: TitoWebhookPayload[] | undefined): string | n
 	return lines.join('\n');
 }
 
-function buildSlackMessage(event: TitoWebhookEvent, payload: TitoWebhookPayload): SlackPayload {
-	const isRegistration = event.startsWith('registration.');
-
-	const releaseTitle = payload.release_title ?? 'Ticket';
-	const headline = isRegistration
-		? `🎟️ Registration finished — ${payload.tickets_count ?? payload.tickets?.length ?? 1} ticket(s)`
-		: `🎟️ ${releaseTitle} purchased`;
+function buildSlackMessage(payload: TitoWebhookPayload): SlackPayload {
+	const ticketCount = payload.tickets_count ?? payload.tickets?.length ?? 1;
+	const headline = `🎟️ Registration finished — ${ticketCount} ticket(s)`;
 
 	const fields: { type: 'mrkdwn'; text: string }[] = [];
 
@@ -72,19 +67,15 @@ function buildSlackMessage(event: TitoWebhookEvent, payload: TitoWebhookPayload)
 
 	if (payload.email) fields.push({ type: 'mrkdwn', text: `*Email:*\n${payload.email}` });
 
-	if (isRegistration) {
-		const ticketSummary = summarizeTickets(payload.tickets);
-		if (ticketSummary) {
-			fields.push({ type: 'mrkdwn', text: `*Tickets:*\n${ticketSummary}` });
-		}
-	} else if (payload.release_title) {
-		fields.push({ type: 'mrkdwn', text: `*Release:*\n${payload.release_title}` });
+	const ticketSummary = summarizeTickets(payload.tickets);
+	if (ticketSummary) {
+		fields.push({ type: 'mrkdwn', text: `*Tickets:*\n${ticketSummary}` });
 	}
 
-	const priceLabel = formatPrice(payload.price ?? payload.total, payload.currency);
+	const priceLabel = formatPrice(payload.total ?? payload.price, payload.currency);
 	if (priceLabel) fields.push({ type: 'mrkdwn', text: `*Price:*\n${priceLabel}` });
 
-	const reference = payload.reference ?? payload.registration_reference;
+	const reference = payload.registration_reference ?? payload.reference;
 	if (reference) fields.push({ type: 'mrkdwn', text: `*Reference:*\n${reference}` });
 
 	const blocks: unknown[] = [
@@ -101,7 +92,7 @@ function buildSlackMessage(event: TitoWebhookEvent, payload: TitoWebhookPayload)
 			elements: [
 				{
 					type: 'mrkdwn',
-					text: `tito · \`${event}\` · ${new Date().toISOString()}`,
+					text: `tito · \`${NOTIFY_EVENT}\` · ${new Date().toISOString()}`,
 				},
 			],
 		},
@@ -154,9 +145,9 @@ export const titoWebhook = onRequest(
 			return;
 		}
 
-		// Only post to Slack for events we care about; ack everything else
+		// Only post to Slack for registration.finished; ack everything else
 		// with 200 so ti.to doesn't keep retrying.
-		if (!NOTIFY_EVENTS.has(eventName)) {
+		if (eventName !== NOTIFY_EVENT) {
 			logger.debug('titoWebhook ignored event', { event: eventName });
 			res.status(200).send('ignored');
 			return;
@@ -172,11 +163,11 @@ export const titoWebhook = onRequest(
 		}
 
 		try {
-			const message = buildSlackMessage(eventName, payload);
+			const message = buildSlackMessage(payload);
 			await postToSlack(SLACK_WEBHOOK_URL.value(), message);
 			logger.info('titoWebhook posted to Slack', {
 				event: eventName,
-				reference: payload.reference ?? payload.registration_reference ?? null,
+				reference: payload.registration_reference ?? payload.reference ?? null,
 			});
 			res.status(200).send('ok');
 		} catch (err) {


### PR DESCRIPTION
## Summary

- Narrow `titoWebhook` allow-list from `{ticket.completed, registration.finished}` to just `registration.finished`.
- Collapse the dual ticket/registration branch in `buildSlackMessage` — payload is always a registration now, so the headline, ticket summary, price (`total` first), and reference (`registration_reference` first) read from the registration shape directly.
- Update `README.md` and `CLAUDE.md` ti.to subscription guidance to match.

## Why

`registration.finished` fires once per completed order and already lists every ticket in the registration. If both events are subscribed in ti.to, each purchase produces a Slack post per ticket *and* a roll-up post for the order — duplicates. Pinning to one event removes that footgun and keeps the function code single-shape.

## Behavior

- ti.to delivery with `X-Webhook-Name: registration.finished` → HMAC verified, Slack post sent (unchanged shape).
- Any other event (incl. `ticket.completed`) → signature still verified, then `200 ignored` so ti.to does not retry. No Slack post.
- Existing ti.to subscriptions need to be edited in ti.to → Customize → Webhook Endpoints to drop `ticket.completed`; the function will silently ignore it either way.

## Files

- `functions/src/tickets/notify-purchase.ts` — single `NOTIFY_EVENT`, simplified `buildSlackMessage`.
- `README.md`, `CLAUDE.md` — subscription guidance updated.