### PR TITLE
feat(tickets): show VAT-inclusive price with "included" tag

### DIFF
--- a/functions/src/tickets/tito-api.ts
+++ b/functions/src/tickets/tito-api.ts
@@ -35,6 +35,12 @@ export interface TitoRelease {
 	title?: string | null;
 	description?: string | null;
 	price?: string | null;
+	/** Net price (excl. tax). Always reliably net regardless of `tax_exclusive`. */
+	price_ex_tax?: string | null;
+	/** True when organizer entered `price` as net (gross = price + tax). */
+	tax_exclusive?: boolean | null;
+	/** Free-text tax label set by organizer (e.g. "VAT 21%"). Not structured. */
+	tax_description?: string | null;
 	currency?: string | null;
 	quantity?: number | null;
 	quantity_sold?: number;
@@ -103,6 +109,9 @@ export const RELEASE_FIELDS = [
 	'title',
 	'description',
 	'price',
+	'price_ex_tax',
+	'tax_exclusive',
+	'tax_description',
 	'currency',
 	'quantity',
 	'quantity_sold',

--- a/src/components/Tickets.module.scss
+++ b/src/components/Tickets.module.scss
@@ -234,12 +234,29 @@
 	color: rgba(26, 18, 8, 0.78);
 }
 
+.variantPriceBlock {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 0.15rem;
+	text-align: right;
+}
+
 .variantPrice {
 	font-family: 'Bebas Neue', sans-serif;
 	font-size: 1.6rem;
 	letter-spacing: 0.04em;
 	line-height: 1;
 	color: #1A1208;
+}
+
+.variantVat {
+	font-family: 'Share Tech Mono', monospace;
+	font-size: 0.7rem;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+	color: rgba(26, 18, 8, 0.6);
+	line-height: 1;
 }
 
 .ticketPrice {

--- a/src/components/Tickets.tsx
+++ b/src/components/Tickets.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import {
 	eventUrl,
 	filterDisplayable,
-	formatPrice,
+	priceDisplay,
 	releaseStatus,
 	releaseTitle,
 	type ReleaseStatus,
@@ -204,11 +204,15 @@ export default function Tickets() {
 							<ul className={s.variants}>
 								{group.variants.map(({ release, variantLabel }) => {
 									const label = variantLabel || releaseTitle(release);
+									const price = priceDisplay(release);
 									return (
 										<li key={release.id} className={s.variant}>
 											<span className={s.variantLabel}>{label}</span>
-											<span className={s.variantPrice}>
-												{formatPrice(release.price, release.currency)}
+											<span className={s.variantPriceBlock}>
+												<span className={s.variantPrice}>{price?.primary}</span>
+												{price?.secondary && (
+													<span className={s.variantVat}>{price.secondary}</span>
+												)}
 											</span>
 										</li>
 									);

--- a/src/lib/tito.ts
+++ b/src/lib/tito.ts
@@ -27,6 +27,12 @@ export interface TitoRelease {
 	title: string | null;
 	description: string | null;
 	price: string | null;
+	/** Net price (excl. tax). Reliably net regardless of `tax_exclusive`. */
+	price_ex_tax?: string | null;
+	/** True when organizer entered `price` as net (gross = price + tax). */
+	tax_exclusive?: boolean | null;
+	/** Free-text tax label set by organizer (e.g. "VAT 21%"). */
+	tax_description?: string | null;
 	currency: string | null;
 	quantity: number | null;
 	quantity_sold: number;
@@ -118,6 +124,56 @@ export function formatPrice(price: string | null, currency: string | null): stri
 	const numeric = Number(price);
 	if (!Number.isFinite(numeric)) return price;
 	if (numeric === 0) return 'Free';
+	return formatAmount(numeric, currency);
+}
+
+/**
+ * Czech standard VAT rate. Used as a fallback when the ti.to release is
+ * configured tax-exclusive (`tax_exclusive=true`) — ti.to's Admin API
+ * does not expose a tax rate or a gross figure on releases, so we apply
+ * the country's statutory rate. If the release is tax-inclusive
+ * (`tax_exclusive=false`), the gross figure is taken directly from
+ * `price` and this constant is not used.
+ */
+export const FALLBACK_VAT_RATE = 0.21;
+
+export interface PriceDisplay {
+	/** Primary amount shown — gross when known, else net. */
+	primary: string;
+	/** Secondary line (e.g. "incl. VAT 21%" / "ex VAT €100"). Null when nothing to add. */
+	secondary: string | null;
+}
+
+/**
+ * Build the price display lines for a release. Always shows the gross
+ * (tax-inclusive) figure as the primary number with a small "VAT
+ * included" tag underneath — visitors see what they actually pay.
+ *
+ * - Tax-inclusive release (`tax_exclusive=false`): `price` is already
+ *   gross. Use it directly.
+ * - Tax-exclusive or unknown: `price` is net. Multiply by
+ *   `FALLBACK_VAT_RATE` because ti.to's Admin API does not expose a
+ *   tax rate on release or event objects.
+ *
+ * Secondary label uses `tax_description` when the organizer set one.
+ */
+export function priceDisplay(release: TitoRelease): PriceDisplay | null {
+	if (release.price == null) return { primary: 'Free', secondary: null };
+	const price = Number(release.price);
+	if (!Number.isFinite(price)) return { primary: release.price, secondary: null };
+	if (price === 0) return { primary: 'Free', secondary: null };
+
+	const currency = release.currency;
+	const label = (release.tax_description ?? '').trim() || 'VAT';
+	const gross = release.tax_exclusive === false ? price : price * (1 + FALLBACK_VAT_RATE);
+
+	return {
+		primary: formatAmount(gross, currency),
+		secondary: `${label} included`,
+	};
+}
+
+function formatAmount(numeric: number, currency: string | null): string {
 	const code = (currency ?? 'EUR').toUpperCase();
 	try {
 		return new Intl.NumberFormat('en-US', {


### PR DESCRIPTION
## Summary
- Ticket card price is now the gross (VAT-inclusive) amount as the big number, with a small mono-caps `VAT included` line underneath.
- Pulled ti.to's tax fields into the RTDB cache so the label and net/gross distinction follow what the organizer configured in the ti.to admin.

## Why
Visitors should see what they actually pay. The previous display used the net ti.to `price` directly, which is the figure the organizer entered (and is net when the release is tax-exclusive — the default ti.to setup). That misled anyone scanning the wave roadmap.

## Behavior
- `priceDisplay(release)` in `src/lib/tito.ts` derives the gross figure:
  - If `tax_exclusive === false` → `price` is already gross, used as-is.
  - Otherwise → gross = `price × 1.21`. The ti.to Admin API does not expose a tax rate anywhere on the release or event, so the Czech statutory rate is used as the fallback constant `FALLBACK_VAT_RATE`.
- Secondary line reads `${tax_description} included` when the organizer set one (e.g. `VAT 21% included`), or `VAT included` otherwise.
- Cloud Function projection now persists `price_ex_tax`, `tax_exclusive`, `tax_description` from the ti.to releases payload into `/tickets` in RTDB. Next hourly `refreshTitoCache` repopulates with the new fields; trigger manually to refresh sooner.

## Files
- `src/lib/tito.ts` — `priceDisplay()` + `PriceDisplay` type; old `formatPriceWithVat` removed.
- `src/components/Tickets.tsx` — renders `primary` + optional `secondary` via `variantPriceBlock` / `variantVat`.
- `src/components/Tickets.module.scss` — `.variantPriceBlock` flex container; `.variantVat` mono-caps label.
- `functions/src/tickets/tito-api.ts` — new tax fields on the `TitoRelease` interface and `RELEASE_FIELDS` projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)