### PR TITLE
fix(seo): use VAT-inclusive price in Event JSON-LD

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -28,8 +28,8 @@ const isHome = Astro.url.pathname === "/";
 
 // `offers.url` points to the on-site #tickets anchor so the schema stays
 // valid even if ti.to slugs change. `price` is the lowest-tier (early-bird)
-// figure used for Google Event rich results — bump this when the wave
-// changes if the lowest live price moves.
+// VAT-inclusive figure used for Google Event rich results — must match the
+// customer-facing price rendered by Tickets.tsx. Bump when the wave changes.
 const eventSchema = {
 	"@context": "https://schema.org",
 	"@type": "Event",
@@ -61,7 +61,7 @@ const eventSchema = {
 	"offers": {
 		"@type": "Offer",
 		"url": `${siteUrl}/#tickets`,
-		"price": "70",
+		"price": "84",
 		"priceCurrency": "EUR",
 		"availability": "https://schema.org/InStock",
 		"validFrom": "2026-05-20T00:00:00+02:00"


### PR DESCRIPTION
## Summary

- Bump `offers.price` in the home-page Event JSON-LD from `70` → `84` so Google rich results match the gross price buyers actually pay.
- Update the inline comment to flag the VAT-inclusive requirement so future wave bumps stay in sync with `Tickets.tsx`.

## Why

#177 switched the ticket UI to display the gross 21 % VAT-inclusive price (`84 EUR`) with a "VAT included" tag, but the schema offer was still the net `70 EUR`. Google's Event/Offer guidance requires `price` to reflect what the customer pays, otherwise rich results can be flagged inconsistent with on-page price.

## Behavior

- No visible UI change.
- JSON-LD in `<head>` on `/` now advertises `"price": "84"` `"priceCurrency": "EUR"`.

## Files

- [src/layouts/BaseLayout.astro](src/layouts/BaseLayout.astro)