### PR TITLE
fix(contact): correct contact email to devfest@gug.cz

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -45,7 +45,7 @@ const SITEMAP = [
 					Prague's developer conference &mdash; Web, Mobile, Cybersecurity, AI/ML.
 				</p>
 				<address class="contact">
-					<a class="email" href="mailto:info@devfest.cz">info@devfest.cz</a>
+					<a class="email" href="mailto:devfest@gug.cz">devfest@gug.cz</a>
 				</address>
 			</section>
 

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -18,7 +18,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 				<p>
 					DevFest.cz 2026 is organised by GDG Czech Republic (Google Developer Group Czech Republic),
 					a volunteer community group. For privacy-related enquiries, contact us at
-					<a href="mailto:info@devfest.cz">info@devfest.cz</a>.
+					<a href="mailto:devfest@gug.cz">devfest@gug.cz</a>.
 				</p>
 			</section>
 
@@ -95,7 +95,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 					<li>Withdraw consent at any time (this does not affect prior processing)</li>
 					<li>Lodge a complaint with the Czech Data Protection Authority (<a href="https://www.uoou.cz" target="_blank" rel="noopener noreferrer">uoou.cz</a>)</li>
 				</ul>
-				<p>To exercise these rights, email us at <a href="mailto:info@devfest.cz">info@devfest.cz</a>.</p>
+				<p>To exercise these rights, email us at <a href="mailto:devfest@gug.cz">devfest@gug.cz</a>.</p>
 			</section>
 
 			<section>


### PR DESCRIPTION
## Summary
- Footer and privacy-policy `mailto:` links pointed to `info@devfest.cz`, which is not a real mailbox.
- Switched both to `devfest@gug.cz`, the address already used on the contact page.

## Why
User report: emails to `info@devfest.cz` bounce / go nowhere. `devfest@gug.cz` is the real GDG Czech inbox.

## Files
- `src/components/Footer.astro`
- `src/pages/privacy-policy.astro` (2 occurrences)