### PR TITLE
fix(tickets): format prices in cs-CZ locale for CZK event

### DIFF
--- a/src/lib/tito.ts
+++ b/src/lib/tito.ts
@@ -174,9 +174,9 @@ export function priceDisplay(release: TitoRelease): PriceDisplay | null {
 }
 
 function formatAmount(numeric: number, currency: string | null): string {
-	const code = (currency ?? 'EUR').toUpperCase();
+	const code = (currency ?? 'CZK').toUpperCase();
 	try {
-		return new Intl.NumberFormat('en-US', {
+		return new Intl.NumberFormat('cs-CZ', {
 			style: 'currency',
 			currency: code,
 			maximumFractionDigits: numeric % 1 === 0 ? 0 : 2,


### PR DESCRIPTION
## Summary
Render ticket prices with the `cs-CZ` locale and default the currency fallback to `CZK` in `formatAmount` (`src/lib/tito.ts`).

## Why
Ticket sales moved to a new ti.to event (`devfest-cz/2026-cs`) priced in CZK. With the previous `en-US` locale, CZK rendered as `CZK 1,990`; `cs-CZ` renders it natively as `1 990 Kč`.

## Behavior
- Cards are data-driven from RTDB `/tickets`, so amounts/currency follow whatever the cache holds. Once the cache repopulates from the new event, prices show as `Kč`.
- Non-CZK currencies still format correctly (locale only changes grouping/symbol placement; `currency` code drives the symbol).

## Follow-up (not in this PR)
- GitHub Actions Variable `TITO_EVENT_SLUG` already updated `2026` → `2026-cs` (account slug unchanged). Functions need a redeploy to pick it up (path-filtered job — re-run the functions workflow or land a `functions/**` change on `2026`).
- Verify the new event's webhook: if per-event, register the `titoWebhook` URL and set `TITO_WEBHOOK_SECRET` in Secret Manager before redeploy.
- Event JSON-LD `Offer` (`src/layouts/BaseLayout.astro`) still hardcodes `price: "84"` / `priceCurrency: "EUR"` — pending the lowest gross CZK price.