### PR TITLE
feat(tickets): add Thursday 18:00 ticket status report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ functions/src/
     ├── slack-client.ts     # `postToSlack()`
     ├── refresh-cache.ts    # `refreshTitoCache`
     ├── notify-purchase.ts  # `titoWebhook`
-    └── weekly-status.ts    # `weeklyTicketStatus`
+    └── weekly-status.ts    # `weeklyTicketStatus` + `thursdayTicketStatus` (shared handler)
 ```
 
 Functions exposed (region `europe-west1`):
@@ -79,6 +79,7 @@ Functions exposed (region `europe-west1`):
 | `refreshTitoCache` | `onSchedule('every 1 hours')` | Fetch releases → write RTDB `/tickets` |
 | `titoWebhook` | `onRequest` (`invoker: 'public'`) | Verify `Tito-Signature` HMAC, post `registration.finished` to Slack (other events 200-acked and ignored) |
 | `weeklyTicketStatus` | `onSchedule('every monday 09:00', Europe/Prague)` | Fetch live releases from ti.to and post sales summary to Slack |
+| `thursdayTicketStatus` | `onSchedule('every thursday 18:00', Europe/Prague)` | Same handler as `weeklyTicketStatus` — second weekly status report |
 
 Browser side: `src/components/Tickets.tsx` subscribes to `/tickets` via `firebase/database`'s `onValue`. `src/lib/tito.ts` holds browser-safe helpers (types, `filterDisplayable`, `checkoutUrl`, `formatPrice`). RTDB rules in `database.rules.json` (not wired into `firebase.json` — paste manually in console).
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The default Cloud Functions service account has the IAM needed to write RTDB; no
 | `refreshTitoCache` | Cloud Scheduler, hourly | Sync ti.to releases → RTDB `/tickets` |
 | `titoWebhook` | HTTPS, public | Verifies `Tito-Signature` and posts purchase notifications to Slack |
 | `weeklyTicketStatus` | Cloud Scheduler, Mondays `09:00 Europe/Prague` | Fetches live releases from ti.to and posts a sales summary to Slack |
+| `thursdayTicketStatus` | Cloud Scheduler, Thursdays `18:00 Europe/Prague` | Same handler as `weeklyTicketStatus` — second weekly status report |
 
 Wire up the webhook in ti.to → Customize → Webhook Endpoints:
 1. Paste the deployed `titoWebhook` URL.

--- a/functions/src/tickets/index.ts
+++ b/functions/src/tickets/index.ts
@@ -5,4 +5,4 @@
 
 export { refreshTitoCache } from './refresh-cache.js';
 export { titoWebhook } from './notify-purchase.js';
-export { weeklyTicketStatus } from './weekly-status.js';
+export { weeklyTicketStatus, thursdayTicketStatus } from './weekly-status.js';

--- a/functions/src/tickets/weekly-status.ts
+++ b/functions/src/tickets/weekly-status.ts
@@ -1,8 +1,12 @@
 /**
- * `weeklyTicketStatus` — once a week, fetch releases directly from the ti.to
- * Admin API and post a sales summary to Slack. The cron is weekly so the
- * extra ti.to request is negligible (1/week, well under the 60/min limit),
- * and reading live data avoids any staleness from the hourly cache.
+ * Ticket status reports — twice a week, fetch releases directly from the ti.to
+ * Admin API and post a sales summary to Slack. The cron runs only twice a week
+ * so the extra ti.to requests are negligible (2/week, well under the 60/min
+ * limit), and reading live data avoids any staleness from the hourly cache.
+ *
+ * Two scheduled functions share one handler (`runTicketStatus`): App Engine
+ * cron can't express two different times-of-day in a single expression, so
+ * Monday 09:00 and Thursday 18:00 are separate `onSchedule` exports.
  */
 
 import { logger } from 'firebase-functions/v2';
@@ -95,7 +99,7 @@ function buildSlackMessage(summary: Summary): SlackPayload {
 	const blocks: unknown[] = [
 		{
 			type: 'header',
-			text: { type: 'plain_text', text: '📊 Weekly ticket status', emoji: true },
+			text: { type: 'plain_text', text: '📊 Ticket status', emoji: true },
 		},
 		{
 			type: 'section',
@@ -123,42 +127,51 @@ function buildSlackMessage(summary: Summary): SlackPayload {
 	];
 
 	return {
-		text: `Weekly ticket status — total sold ${totalLabel}`,
+		text: `Ticket status — total sold ${totalLabel}`,
 		blocks,
 	};
 }
 
-/**
- * Weekly on Monday at 09:00 Europe/Prague. Fetches live data from ti.to (no RTDB).
- */
+/** Shared cron options for both status-report schedules. */
+const SCHEDULE_OPTS = {
+	timeZone: 'Europe/Prague',
+	region: REGION,
+	secrets: [SLACK_WEBHOOK_URL, TITO_API_TOKEN],
+	timeoutSeconds: 120,
+	memory: '256MiB' as const,
+	retryCount: 1,
+};
+
+/** Fetch live releases from ti.to and post a sales summary to Slack. */
+async function runTicketStatus(): Promise<void> {
+	const token = TITO_API_TOKEN.value();
+	const accountSlug = TITO_ACCOUNT_SLUG.value();
+	const eventSlug = TITO_EVENT_SLUG.value();
+
+	if (!token || !accountSlug || !eventSlug) {
+		throw new Error(
+			'Missing config: TITO_API_TOKEN secret and TITO_ACCOUNT_SLUG / TITO_EVENT_SLUG params must be set.',
+		);
+	}
+
+	const releases = await fetchAllReleases({ token, accountSlug, eventSlug });
+	const summary = summarize(releases);
+	await postToSlack(SLACK_WEBHOOK_URL.value(), buildSlackMessage(summary));
+
+	logger.info('ticket status posted', {
+		totalSold: summary.totalSold,
+		releaseCount: summary.releases.length,
+	});
+}
+
+/** Monday at 09:00 Europe/Prague. Fetches live data from ti.to (no RTDB). */
 export const weeklyTicketStatus = onSchedule(
-	{
-		schedule: 'every monday 09:00',
-		timeZone: 'Europe/Prague',
-		region: REGION,
-		secrets: [SLACK_WEBHOOK_URL, TITO_API_TOKEN],
-		timeoutSeconds: 120,
-		memory: '256MiB',
-		retryCount: 1,
-	},
-	async () => {
-		const token = TITO_API_TOKEN.value();
-		const accountSlug = TITO_ACCOUNT_SLUG.value();
-		const eventSlug = TITO_EVENT_SLUG.value();
+	{ ...SCHEDULE_OPTS, schedule: 'every monday 09:00' },
+	runTicketStatus,
+);
 
-		if (!token || !accountSlug || !eventSlug) {
-			throw new Error(
-				'Missing config: TITO_API_TOKEN secret and TITO_ACCOUNT_SLUG / TITO_EVENT_SLUG params must be set.',
-			);
-		}
-
-		const releases = await fetchAllReleases({ token, accountSlug, eventSlug });
-		const summary = summarize(releases);
-		await postToSlack(SLACK_WEBHOOK_URL.value(), buildSlackMessage(summary));
-
-		logger.info('weeklyTicketStatus posted', {
-			totalSold: summary.totalSold,
-			releaseCount: summary.releases.length,
-		});
-	},
+/** Thursday at 18:00 Europe/Prague. Fetches live data from ti.to (no RTDB). */
+export const thursdayTicketStatus = onSchedule(
+	{ ...SCHEDULE_OPTS, schedule: 'every thursday 18:00' },
+	runTicketStatus,
 );


### PR DESCRIPTION
## Summary

Adds a second ti.to sales summary to Slack: **Thursdays at 18:00 Europe/Prague**, alongside the existing Monday 09:00 report.

## Why

One status post a week leaves a long gap mid-week. A Thursday-evening report gives a fresh sales snapshot before the weekend.

## Behavior

- `weekly-status.ts` now exports **two** scheduled functions sharing one handler (`runTicketStatus`):
  - `weeklyTicketStatus` — `every monday 09:00`
  - `thursdayTicketStatus` — `every thursday 18:00`
- App Engine cron can't express two different times-of-day in a single expression, hence two `onSchedule` exports rather than one combined schedule.
- Slack message header changed `"📊 Weekly ticket status"` → `"📊 Ticket status"` (and the fallback `text`), since it no longer fires only weekly.
- Both run live against the ti.to Admin API (no RTDB), same as before.

## Files

- `functions/src/tickets/weekly-status.ts` — extract shared handler, add second schedule, retitle message
- `functions/src/tickets/index.ts` — re-export `thursdayTicketStatus`
- `CLAUDE.md`, `README.md` — function tables updated

## Deploy note

`thursdayTicketStatus` is a **new** Cloud Function — `firebase deploy --only functions` to create it. Reuses the existing `SLACK_WEBHOOK_URL` / `TITO_API_TOKEN` secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)