### PR TITLE
feat(partners): wire live partnership deck link

### DIFF
--- a/src/pages/partners.astro
+++ b/src/pages/partners.astro
@@ -4,10 +4,8 @@ import Footer from '../components/Footer.astro';
 import SubpageHero from '../components/SubpageHero.astro';
 import Ticker from '../components/Ticker.astro';
 
-// Partnership deck is still in production. Once it lands (PDF / Google Slides / Notion),
-// flip `DECK_READY` to true and set `PRESENTATION_URL`.
-const DECK_READY = false;
-const PRESENTATION_URL = '#partners-deck-todo';
+const DECK_READY = true;
+const PRESENTATION_URL = 'https://canva.link/828fiq93km2hwds';
 const FILIP = { name: 'Filip Goszler', role: 'Partnerships', email: 'filip@gug.cz' };
 
 // Media partners — logos live in public/partners/media/.


### PR DESCRIPTION
## Summary

Partnership deck link is finally available, so the partners CTA no longer needs to show "Coming soon".

- Flip `DECK_READY` → `true`
- Set `PRESENTATION_URL` to the Canva deck (`https://canva.link/828fiq93km2hwds`)

## Behavior

The partners-page CTA now renders the active **"See partnership deck →"** link (opens in a new tab) instead of the disabled "Partnership deck — Coming soon" stamp. Note text switches to "Tiers, perks, and audience stats in one PDF."

## Files

- `src/pages/partners.astro` — toggle the deck flag + URL

## Follow-up

The disabled-state branch (`partners-cta-soon` stamp) and its styles (`.partners-cta-soon`, `.partners-cta-stamp`, `deckPulse`) are now dead but kept intentionally — flip `DECK_READY` back to `false` to restore the "coming soon" state. Can strip them in a later cleanup if the toggle is no longer wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)