### PR TITLE
feat(home): add call-for-speakers section linking to CFP

### DIFF
--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -11,6 +11,7 @@ const isHome = currentPath === '/';
 // On the home page #tickets is a same-page anchor; from subpages we need
 // to send the visitor back to / first so the section actually exists.
 const ticketsHref = isHome ? '#tickets' : '/#tickets';
+const speakersHref = isHome ? '#speakers' : '/#speakers';
 
 const links: readonly NavLink[] = [
 	{ href: '/partners', label: 'Partners' },
@@ -18,6 +19,7 @@ const links: readonly NavLink[] = [
 	{ href: '/faq', label: 'FAQ' },
 	{ href: '/contact', label: 'Contact' },
 	{ href: 'https://2025.devfest.cz', label: '2025 Edition', external: true },
+	{ href: speakersHref, label: 'Speak' },
 	{ href: ticketsHref, label: 'Tickets', cta: true },
 ];
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -77,6 +77,28 @@ const tickerTopics = [
 		<!-- TICKER -->
 		<Ticker items={tickerTopics} />
 
+		<!-- CALL FOR SPEAKERS -->
+		<section id="speakers" aria-labelledby="speakers-title">
+			<div class="speakers-inner">
+				<p class="section-label">Call for speakers</p>
+				<h2 id="speakers-title" class="section-title">
+					Wanted: <span class="red">your talk.</span>
+				</h2>
+				<p class="speakers-lede">
+					The DevFest.cz 2026 stage is now taking submissions. Got a story worth telling&mdash;AI, Android, web, cloud, Flutter, security, open source? Make your case.
+				</p>
+				<div class="speakers-cta-group">
+					<a
+						href="https://sessionize.com/devfest-cz-2026"
+						class="btn-primary"
+						target="_blank"
+						rel="noopener"
+					>Submit a talk</a>
+					<span class="speakers-tag">CFP open now</span>
+				</div>
+			</div>
+		</section>
+
 		<!-- TICKETS -->
 		<Tickets client:visible />
 

--- a/src/pages/index.scss
+++ b/src/pages/index.scss
@@ -351,6 +351,79 @@
 		to   { transform: translateX(-50%); }
 	}
 
+	/* ===================== CALL FOR SPEAKERS ===================== */
+	#speakers {
+		position: relative;
+		padding: 8rem 3rem;
+		width: 100%;
+		overflow: hidden;
+		background: var(--color-bg);
+		border-top: 1px solid rgba(204, 0, 0, 0.18);
+		border-bottom: 1px solid rgba(204, 0, 0, 0.18);
+
+		&::before {
+			content: '';
+			position: absolute;
+			inset: 0;
+			background:
+				radial-gradient(ellipse 50% 60% at 15% 8%, rgba(204, 0, 0, 0.1) 0%, transparent 60%),
+				radial-gradient(ellipse 45% 65% at 88% 96%, rgba(139, 24, 24, 0.09) 0%, transparent 60%);
+			pointer-events: none;
+			z-index: 0;
+		}
+	}
+
+	.speakers-inner {
+		position: relative;
+		z-index: 1;
+		max-width: 620px;
+		margin: 0 auto;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+
+		.section-label {
+			justify-content: center;
+
+			// trailing hairline reads off-centre on a centred eyebrow
+			&::after { display: none; }
+		}
+
+		.section-title {
+			margin-bottom: 1.6rem;
+		}
+	}
+
+	.speakers-lede {
+		font-family: 'IM Fell English', serif;
+		font-style: italic;
+		font-size: 1.05rem;
+		line-height: 1.75;
+		color: var(--color-grey);
+		max-width: 480px;
+		margin: 0 auto 2.6rem;
+	}
+
+	.speakers-cta-group {
+		display: flex;
+		align-items: center;
+		gap: 1.6rem;
+		flex-wrap: wrap;
+		justify-content: center;
+	}
+
+	.speakers-tag {
+		font-family: 'Share Tech Mono', monospace;
+		font-size: 0.74rem;
+		letter-spacing: 0.22em;
+		text-transform: uppercase;
+		color: var(--color-accent-hot);
+		padding: 0.42em 0.8em;
+		border: 1px solid rgba(204, 0, 0, 0.4);
+		white-space: nowrap;
+	}
+
 	/* ===================== SHARED SECTION ===================== */
 	#newsletter {
 		padding: 8rem 3rem;
@@ -493,6 +566,7 @@
 		.hero-meta { gap: 2.2rem; }
 		.hero-countdown { padding: 1.6rem 1.2rem 1.4rem; }
 		#newsletter { padding: 6.5rem 1.5rem; }
+		#speakers { padding: 6.5rem 1.5rem; }
 		#gallery { padding: 6.5rem 0 6rem; }
 		.gallery-head { padding: 0 1.5rem; margin-bottom: 3.5rem; }
 		.gallery-marquee { padding: 1.8rem 0; }
@@ -523,6 +597,7 @@
 		.btn-ghost { font-size: 0.85rem; }
 		.section-label::after { flex-basis: 32px; }
 		#newsletter { padding: 5rem 1.1rem; }
+		#speakers { padding: 5rem 1.1rem; }
 	}
 
 	@media (max-width: 380px) {
@@ -532,6 +607,7 @@
 		.btn-primary { padding: 0.85rem 1.4rem; font-size: 0.82rem; letter-spacing: 0.18em; }
 		.btn-ghost { font-size: 0.82rem; letter-spacing: 0.18em; }
 		#newsletter { padding: 4.5rem 0.85rem; }
+		#speakers { padding: 4.5rem 0.85rem; }
 	}
 
 	@media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary

Adds a **Call for speakers** section to the home page, inviting talk submissions to the DevFest.cz 2026 Sessionize CFP (https://sessionize.com/devfest-cz-2026).

## Why

We're now looking for speakers — the CFP is open and needs a prominent, discoverable entry point on the landing page.

## Behavior

- New `#speakers` section sits between the topics ticker and the tickets block, so the narrative flows: topics → "want to speak on these? submit" → tickets.
- Noir "Wanted: your talk" framing with a `Submit a talk` stamp CTA → Sessionize (opens in new tab) and a `CFP open now` mono tag.
- New `Speak` nav link anchors to `#speakers` (uses the existing tickets anchor pattern — `/#speakers` from subpages).
- Reuses existing `section-label` / `section-title` / `btn-primary` primitives and the dossier styling; responsive padding at 900/600/380px.
- No CFP deadline was provided, so the tag reads "CFP open now" rather than inventing a date.

## Files

- `src/pages/index.astro` — new section markup
- `src/pages/index.scss` — `#speakers` styles + responsive
- `src/components/Menu.astro` — `Speak` nav link

## Verification

- `npm run build` passes (10 pages); built HTML confirms the section, CTA link, and nav entry.

## Follow-up

- `faq.astro` still routes speaker enquiries to `devfest-speakers@gug.cz` — left as-is (email for questions vs. CFP form for submissions). Could link Sessionize there too if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)