### PR TITLE
fix(faq): soften venue location to "Prague or just outside the city"

### DIFF
--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -33,7 +33,7 @@ const faqGroups: FaqGroup[] = [
 		items: [
 			{
 				q: 'When and where is DevFest.cz 2026?',
-				a: 'DevFest.cz 2026 takes place on <strong>30 October 2026</strong> in Prague, fully in person. The exact venue is still under wraps — sign up to the <a href="/#newsletter">newsletter</a> to be the first to know.',
+				a: 'DevFest.cz 2026 takes place on <strong>30 October 2026</strong> in Prague or just outside the city, fully in person. The exact venue is still under wraps — sign up to the <a href="/#newsletter">newsletter</a> to be the first to know.',
 			},
 			{
 				q: 'Who organises DevFest.cz?',
@@ -122,7 +122,7 @@ const faqJsonLd = JSON.stringify(faqSchema);
 
 <BaseLayout
 	title="FAQ — DevFest.cz 2026"
-	description="Frequently asked questions about DevFest.cz 2026 — tickets, venue, travel, program, and what to expect on the day in Prague."
+	description="Frequently asked questions about DevFest.cz 2026 — tickets, venue, travel, program, and what to expect on the day."
 >
 	<script type="application/ld+json" slot="head" set:html={faqJsonLd} />
 


### PR DESCRIPTION
## Summary

Libčice is still in play as a venue candidate, so pinning the FAQ answer to "in Prague" is premature.

- FAQ answer: `in Prague` → `in Prague or just outside the city`
- Meta description: removed the trailing `in Prague` (no longer accurate either way)