### PR TITLE
fix(ui): reduce color banding on low-quality monitors

### DIFF
--- a/src/components/HeroBackground.scss
+++ b/src/components/HeroBackground.scss
@@ -19,16 +19,20 @@
 		mask-image: linear-gradient(
 			to right,
 			transparent 0%,
-			rgba(0, 0, 0, 0.35) 12%,
-			rgba(0, 0, 0, 0.85) 30%,
-			#000 55%
+			rgba(0, 0, 0, 0.08) 6%,
+			rgba(0, 0, 0, 0.28) 15%,
+			rgba(0, 0, 0, 0.62) 26%,
+			rgba(0, 0, 0, 0.88) 38%,
+			#000 56%
 		);
 		-webkit-mask-image: linear-gradient(
 			to right,
 			transparent 0%,
-			rgba(0, 0, 0, 0.35) 12%,
-			rgba(0, 0, 0, 0.85) 30%,
-			#000 55%
+			rgba(0, 0, 0, 0.08) 6%,
+			rgba(0, 0, 0, 0.28) 15%,
+			rgba(0, 0, 0, 0.62) 26%,
+			rgba(0, 0, 0, 0.88) 38%,
+			#000 56%
 		);
 		opacity: var(--hero-photo-opacity, 0.85);
 		pointer-events: none;

--- a/src/pages/index.scss
+++ b/src/pages/index.scss
@@ -218,7 +218,7 @@
 		position: relative;
 		padding: 8.5rem 0 8rem;
 		background:
-			linear-gradient(180deg, var(--color-bg) 0%, var(--color-near-black) 12%, var(--color-near-black) 88%, var(--color-bg) 100%);
+			linear-gradient(180deg, var(--color-bg) 0%, var(--color-near-black) 28%, var(--color-near-black) 72%, var(--color-bg) 100%);
 		overflow: hidden;
 		border-top: 1px solid rgba(204, 0, 0, 0.18);
 		border-bottom: 1px solid rgba(204, 0, 0, 0.18);
@@ -429,7 +429,7 @@
 		padding: 8rem 3rem;
 		position: relative;
 		width: 100%;
-		background: var(--color-near-black);
+		background: var(--color-bg);
 	}
 
 	.newsletter-inner {


### PR DESCRIPTION
## Summary

On TN/VA panels with poor gamma linearity in dark tones, near-identical background color transitions (`#050505` → `#0D0D0D`) produce Mach banding — a visible line at the gradient inflection point. Three targeted fixes:

- **Hero photo mask** — added two extra gradient stops and spread the transition from 0–55% to 0–56% with a shallower alpha curve; the left edge of the detective photo now blends more gradually into the dark background.
- **Gallery gradient** — widened transition zones from `12%`/`88%` to `28%`/`72%`; the near-black fade covers significantly more vertical space, eliminating the visible band on cheaper displays.
- **Newsletter section** — changed `background` from `var(--color-near-black)` to `var(--color-bg)`, removing an unnecessary color switch in the middle of the page that served no visual purpose.