### PR TITLE
feat(footer): add open-source repo link

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -119,6 +119,14 @@ const SITEMAP = [
 			<small class="copyright">
 				&copy; 2026 GUG.cz, z.s. &mdash; All rights reserved.
 			</small>
+			<small class="opensource">
+				<a
+					class="footer-link"
+					href="https://github.com/gugcz/devfest-website"
+					target="_blank"
+					rel="noopener noreferrer"
+				>Open source<span class="ext" aria-hidden="true"> &#8599;</span></a>
+			</small>
 		</div>
 	</div>
 </footer>

--- a/src/components/Footer.scss
+++ b/src/components/Footer.scss
@@ -246,3 +246,12 @@
 	.copyright {
 		font-size: inherit;
 	}
+
+	.opensource {
+		font-size: inherit;
+
+		&::before {
+			content: '\00b7';
+			margin: 0 0.6em;
+		}
+	}


### PR DESCRIPTION
## Summary

- Adds an "Open source ↗" link in the footer bottom bar pointing to https://github.com/gugcz/devfest-website
- Separated from the copyright notice by a mid-dot (`·`) via CSS `::before`
- Uses existing `footer-link` class so hover/colour behaviour is consistent