### PR TITLE
feat(seo): enrich ticket structured data + FAQ pricing

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -26,10 +26,19 @@ const ogImageAlt = "DevFest.cz 2026 conference banner";
 // claim to BE the event. WebSite + Organization render sitewide.
 const isHome = Astro.url.pathname === "/";
 
-// `offers.url` points to the on-site #tickets anchor so the schema stays
-// valid even if ti.to slugs change. `price` is the lowest-tier (early-bird)
-// VAT-inclusive figure used for Google Event rich results — must match the
-// customer-facing price rendered by Tickets.tsx. Bump when the wave changes.
+// `offers[].url` points to the on-site #tickets anchor so the schema stays
+// valid even if ti.to slugs change. Prices are VAT-inclusive CZK figures
+// (gross = ti.to net × 1.21 Czech VAT) and must match the customer-facing
+// prices rendered by Tickets.tsx via priceDisplay(). The event is priced in
+// CZK on ti.to (see #182) — do NOT use EUR here. Only Early Bird is on sale;
+// Regular/Lazy Bird are paused ("Coming soon") so they carry a price but no
+// `availability` per Google's "not yet on sale → omit availability" guidance.
+// Bump these figures when a wave opens/closes (source of truth: ti.to/RTDB).
+const organizer = {
+	"@type": "Organization",
+	"name": "GUG.cz, z.s.",
+	"url": "https://gug.cz"
+};
 const eventSchema = {
 	"@context": "https://schema.org",
 	"@type": "Event",
@@ -43,6 +52,7 @@ const eventSchema = {
 	"eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
 	"eventStatus": "https://schema.org/EventScheduled",
 	"inLanguage": "en",
+	"keywords": "developer conference, technology conference, Prague, web development, Android, Flutter, AI, cybersecurity, DevFest",
 	"location": {
 		"@type": "Place",
 		"name": "Prague",
@@ -53,19 +63,38 @@ const eventSchema = {
 			"addressCountry": "CZ"
 		}
 	},
-	"organizer": {
-		"@type": "Organization",
-		"name": "GUG.cz, z.s.",
-		"url": "https://gug.cz"
-	},
-	"offers": {
-		"@type": "Offer",
-		"url": `${siteUrl}/#tickets`,
-		"price": "84",
-		"priceCurrency": "EUR",
-		"availability": "https://schema.org/InStock",
-		"validFrom": "2026-05-20T00:00:00+02:00"
-	}
+	"organizer": organizer,
+	"offers": [
+		{
+			"@type": "Offer",
+			"name": "Early Bird",
+			"description": "Limited early-access tickets at the lowest price of the event.",
+			"url": `${siteUrl}/#tickets`,
+			"price": "2099",
+			"priceCurrency": "CZK",
+			"availability": "https://schema.org/InStock",
+			"validFrom": "2026-05-20T00:00:00+02:00",
+			"seller": organizer
+		},
+		{
+			"@type": "Offer",
+			"name": "Regular",
+			"description": "Standard-wave tickets — opens after Early Bird sells out.",
+			"url": `${siteUrl}/#tickets`,
+			"price": "2999",
+			"priceCurrency": "CZK",
+			"seller": organizer
+		},
+		{
+			"@type": "Offer",
+			"name": "Lazy Bird",
+			"description": "Last-chance tickets at late pricing — same full conference access.",
+			"url": `${siteUrl}/#tickets`,
+			"price": "3599",
+			"priceCurrency": "CZK",
+			"seller": organizer
+		}
+	]
 };
 
 const organizationSchema = {

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -50,6 +50,14 @@ const faqGroups: FaqGroup[] = [
 		label: 'Tickets',
 		items: [
 			{
+				q: 'How much do tickets cost?',
+				a: 'Tickets are sold in three waves — <strong>Early Bird</strong>, <strong>Regular</strong>, and <strong>Lazy Bird</strong> — with the price rising each wave. Early Bird tickets start from <strong>2 099 Kč (VAT included)</strong>. Live pricing for the current wave is always shown in the <a href="/#tickets">Tickets</a> section on the home page.',
+			},
+			{
+				q: 'What ticket types are available?',
+				a: 'Each wave offers two options: <strong>Individual</strong> (personal purchase) and <strong>Company funded</strong> (priced for employer-reimbursed purchases). Both grant full access to the conference.',
+			},
+			{
 				q: 'How do I get tickets?',
 				a: 'Live availability and pricing are shown in the <a href="/#tickets">Tickets</a> section on the home page. Tickets are released in waves — the earlier you grab one, the better the price.',
 			},


### PR DESCRIPTION
## Summary

Improve SEO for tickets across the Event JSON-LD and the FAQ:

- **Event schema** — expand `offers` from a single Offer into a per-wave array (Early Bird / Regular / Lazy Bird), each with `seller` (GUG.cz, z.s.) and a description. Add `keywords` to the Event.
- **FAQ** — add two ticket questions ("How much do tickets cost?", "What ticket types are available?") so the FAQPage rich result surfaces pricing and the Individual vs Company-funded split.

## Why

The home-page `<Tickets>` island loads release data from Firebase at runtime, so crawlers see only a skeleton — no ticket names or prices in the static HTML. The Event/FAQPage structured data is the reliable place to give Google ticket info for rich results.

## Behavior

Prices are sourced from the **live ti.to/RTDB** releases as VAT-inclusive CZK (gross = net x 1.21), matching what `priceDisplay()` renders in the Tickets section:

| Offer | Price | Availability |
| --- | --- | --- |
| Early Bird | 2 099 Kc | InStock (`validFrom` set) |
| Regular | 2 999 Kc | omitted (paused / coming soon) |
| Lazy Bird | 3 599 Kc | omitted (paused / coming soon) |

The event moved to **CZK pricing in #182**, so the prior hardcoded `84 EUR` schema figure was stale. Both the schema and the new FAQ copy now state CZK. Only Early Bird is on sale, so Regular/Lazy Bird carry a price but omit `availability` per Google's "not yet on sale -> omit availability" guidance (avoids misleading PreOrder semantics).

Verified: `npm run build` clean; both `dist/index.html` and `dist/faq/index.html` JSON-LD parse and reflect the CZK offers + new FAQ entries.

## Files

- `src/layouts/BaseLayout.astro` — Event `offers` array, `seller`, `keywords`
- `src/pages/faq.astro` — two ticket FAQ entries (also feed the FAQPage JSON-LD)

## Follow-up

Schema prices and the FAQ figure are hardcoded and match live now — **bump them when a wave opens/closes** (source of truth: ti.to/RTDB). The Tickets card itself stays dynamic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)