### PR TITLE
fix(seo): drop not-yet-on-sale offers from event structured data

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -30,10 +30,12 @@ const isHome = Astro.url.pathname === "/";
 // valid even if ti.to slugs change. Prices are VAT-inclusive CZK figures
 // (gross = ti.to net × 1.21 Czech VAT) and must match the customer-facing
 // prices rendered by Tickets.tsx via priceDisplay(). The event is priced in
-// CZK on ti.to (see #182) — do NOT use EUR here. Only Early Bird is on sale;
-// Regular/Lazy Bird are paused ("Coming soon") so they carry a price but no
-// `availability` per Google's "not yet on sale → omit availability" guidance.
-// Bump these figures when a wave opens/closes (source of truth: ti.to/RTDB).
+// CZK on ti.to (see #182) — do NOT use EUR here. Only list waves that are
+// actually on sale: future waves (Regular/Lazy Bird) are paused with no
+// scheduled start date, so they carry no honest `availability`/`validFrom`
+// and are omitted entirely until they open (avoids Google's missing-field
+// warning). Add an Offer here when a wave opens; remove it when it ends
+// (source of truth: ti.to/RTDB).
 const organizer = {
 	"@type": "Organization",
 	"name": "GUG.cz, z.s.",
@@ -74,24 +76,6 @@ const eventSchema = {
 			"priceCurrency": "CZK",
 			"availability": "https://schema.org/InStock",
 			"validFrom": "2026-05-20T00:00:00+02:00",
-			"seller": organizer
-		},
-		{
-			"@type": "Offer",
-			"name": "Regular",
-			"description": "Standard-wave tickets — opens after Early Bird sells out.",
-			"url": `${siteUrl}/#tickets`,
-			"price": "2999",
-			"priceCurrency": "CZK",
-			"seller": organizer
-		},
-		{
-			"@type": "Offer",
-			"name": "Lazy Bird",
-			"description": "Last-chance tickets at late pricing — same full conference access.",
-			"url": `${siteUrl}/#tickets`,
-			"price": "3599",
-			"priceCurrency": "CZK",
 			"seller": organizer
 		}
 	]


### PR DESCRIPTION
## Summary

Remove the **Regular** and **Lazy Bird** `Offer` objects from the Event JSON-LD in `BaseLayout.astro`, leaving only **Early Bird** (the wave that's actually on sale).

## Why

Google Search Console flagged a non-critical warning: *"Missing field `availability` (in offers)"* on the Event structured data.

- `offers.availability` is a **recommended** field. Google recognizes only `InStock`, `SoldOut`, `PreOrder`.
- Regular/Lazy Bird are future waves — paused in ti.to with **no scheduled start date**. They carried a price but no honest `availability` or `validFrom`, which is exactly what triggered the warning.
- Per [Google's Event guidance](https://developers.google.com/search/docs/appearance/structured-data/event), only offers that are on sale should be listed. Future waves don't belong in the schema until they open.

## Behavior

- `offers` now contains a single Early Bird entry (`availability: InStock`, `validFrom: 2026-05-20`). No missing-field warning.
- No visual/runtime change — JSON-LD only.

## Follow-up

Re-add an `Offer` block per wave when it opens (prior prices: Regular 2999 CZK, Lazy Bird 3599 CZK — VAT-inclusive). The updated comment in `BaseLayout.astro` documents this.