### PR TITLE
feat(appcheck): wire Firebase App Check with reCAPTCHA Enterprise

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Astro client env. Copy to `.env` and fill in. Only PUBLIC_* vars are exposed
+# to the browser bundle (Astro convention).
+
+# Firebase App Check — reCAPTCHA Enterprise key ID (GCP → Security → reCAPTCHA,
+# score-based key for websites). App Check stays inert until this is set; safe to
+# embed (public key ID).
+PUBLIC_FIREBASE_APPCHECK_SITE_KEY=
+
+# Local dev only: set to `true` to print a debug token in the browser console,
+# then register it under App Check → Apps → Manage debug tokens. Or paste an
+# already-registered token here. Leave empty in production.
+PUBLIC_FIREBASE_APPCHECK_DEBUG_TOKEN=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ Static Astro components (`.astro`) for layout and non-interactive UI. React comp
 
 Firebase Analytics is initialized **only after cookie consent** — it listens for the `cookie-consent-accepted` custom event. Firebase Realtime Database is configured but not currently used. Deployment targets the `devfest-public` site in the `devfest-cz-app` project via `firebase.json`.
 
+App Check (reCAPTCHA Enterprise) runs in `getApp()` with a committed key (`APPCHECK_SITE_KEY` in `src/lib/firebase.ts`; `PUBLIC_FIREBASE_APPCHECK_SITE_KEY` overrides it — `src/env.d.ts` types it, `.env.example` documents it). The key is public like the Firebase `apiKey`. Tokens already attach to RTDB reads, but reads keep working until **enforcement** is toggled on for Realtime Database in the Firebase console (do that only after metrics show real traffic is verified). It runs unconditionally, **not** gated on cookie consent, because RTDB reads in `Tickets.tsx` fire on mount before any consent — App Check is a security mechanism (legitimate interest), not analytics. Only RTDB `/tickets` is in scope; `titoWebhook` (external ti.to caller, HMAC-protected) must stay out. See README "App Check".
+
 ### ti.to Tickets pipeline
 
 Visitor browsers read ticket data from RTDB `/tickets`. The static build never calls ti.to. Cloud Functions own all ti.to traffic.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,38 @@ Wire up the webhook in ti.to → Customize → Webhook Endpoints:
 
 While the Tickets section is hidden on the site, `/tickets` is locked down (`.read: false`) so the cache cannot be pulled from outside. The Cloud Functions still write to it via the Admin SDK (which bypasses rules). When the site is ready to launch, flip `tickets.".read"` to `true` and re-deploy / re-paste the rules.
 
+### App Check
+
+App Check attests that RTDB reads come from the real site, not a scraper. The
+web client uses **reCAPTCHA Enterprise** in `src/lib/firebase.ts` with the key
+committed (`APPCHECK_SITE_KEY` — public, like the Firebase `apiKey`). App Check
+tokens already attach to RTDB reads; reads keep working until you toggle
+enforcement on, so it's safe to ship before enforcing.
+
+**Scope.** Only the public surface needs it: RTDB `/tickets`, which the browser
+reads directly. The `titoWebhook` function is called by ti.to (an external
+server that cannot mint an App Check token) and is already protected by an HMAC
+signature — **do not** enforce App Check on it. The scheduled functions take no
+public traffic, so App Check is irrelevant there.
+
+Remaining steps (do 1–3 before turning on enforcement):
+
+1. **Register the key in Firebase App Check.** GCP console (project
+   `devfest-cz-app`) → Security → reCAPTCHA holds the **score-based website key**
+   (`6Lf…zV92P`); add `devfest.cz` and any preview domains to its allowed
+   domains. Then Firebase console → App Check → Apps: register the web app and
+   point it at that reCAPTCHA Enterprise key. (Per-environment override: set
+   `PUBLIC_FIREBASE_APPCHECK_SITE_KEY` in `.env` to use a different key ID.)
+2. **Local dev.** Set `PUBLIC_FIREBASE_APPCHECK_DEBUG_TOKEN=true` in `.env`, load
+   the site, copy the debug token from the console, and register it under
+   App Check → Apps → Manage debug tokens. Leave this empty in production.
+3. **Watch metrics.** With tokens flowing but enforcement still off, App Check →
+   APIs shows the verified-vs-unverified split for Realtime Database. Wait until
+   nearly all real traffic is verified.
+4. **Enforce.** Once the metrics look clean, turn on enforcement for **Realtime
+   Database** in App Check → APIs. This is a console toggle — no code or
+   `database.rules.json` change. Leave Cloud Functions enforcement off.
+
 ### Filtering
 
 Only releases that are on sale or sold out are displayed. Archived, secret, expired, upcoming, paused (`off_sale` / `locked`) releases are dropped server-side before writing to RTDB, with the same predicate applied again client-side as defence-in-depth. A single `sale_status` string is synthesised from ti.to's flag set (`sold_out`, `off_sale`, `expired`, `upcoming`, `archived`, `locked`) — see `functions/src/tickets/tito-api.ts::deriveSaleStatus`.

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,25 @@
+/// <reference types="astro/client" />
+
+interface ImportMetaEnv {
+	/**
+	 * reCAPTCHA Enterprise key ID for Firebase App Check. App Check stays inert
+	 * (no token attached to RTDB reads) while this is unset.
+	 */
+	readonly PUBLIC_FIREBASE_APPCHECK_SITE_KEY?: string;
+	/**
+	 * Local-only App Check debug token. Set to `true` to make the SDK print a
+	 * token in the browser console (register it under App Check → Apps → Manage
+	 * debug tokens), or paste an already-registered token string. Never set in
+	 * production.
+	 */
+	readonly PUBLIC_FIREBASE_APPCHECK_DEBUG_TOKEN?: string;
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv;
+}
+
+interface Window {
+	/** Firebase App Check debug-token hook (dev only). */
+	FIREBASE_APPCHECK_DEBUG_TOKEN?: boolean | string;
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,4 +1,5 @@
 import { initializeApp, type FirebaseApp } from 'firebase/app';
+import { initializeAppCheck, ReCaptchaEnterpriseProvider, type AppCheck } from 'firebase/app-check';
 import { getAnalytics, isSupported, type Analytics } from 'firebase/analytics';
 import { getDatabase, type Database } from 'firebase/database';
 
@@ -15,8 +16,51 @@ const firebaseConfig = {
 
 let appInstance: FirebaseApp | null = null;
 function getApp(): FirebaseApp {
-	if (!appInstance) appInstance = initializeApp(firebaseConfig);
+	if (!appInstance) {
+		appInstance = initializeApp(firebaseConfig);
+		initAppCheck(appInstance);
+	}
 	return appInstance;
+}
+
+// reCAPTCHA Enterprise key ID. Public, like the Firebase `apiKey` above — safe
+// to commit. Used as the default App Check key; PUBLIC_FIREBASE_APPCHECK_SITE_KEY
+// overrides it (e.g. a separate key per environment).
+const APPCHECK_SITE_KEY = '6LftoSYtAAAAAC3KOtITOv99JybWgVfkSq-zV92P';
+
+let appCheckInstance: AppCheck | null = null;
+/**
+ * Initialise Firebase App Check (reCAPTCHA Enterprise) so RTDB reads carry an
+ * attestation token. Runs once, on the same FirebaseApp every consumer uses,
+ * so the token is in place before `getDb()` issues any read.
+ *
+ * No-ops on the server and whenever no site key is configured. App Check tokens
+ * attach to RTDB reads as soon as this runs, but reads keep working until
+ * enforcement is switched on for Realtime Database in the Firebase console.
+ */
+function initAppCheck(app: FirebaseApp): void {
+	if (appCheckInstance) return;
+	if (typeof window === 'undefined') return;
+
+	const siteKey = import.meta.env.PUBLIC_FIREBASE_APPCHECK_SITE_KEY ?? APPCHECK_SITE_KEY;
+	if (!siteKey) return;
+
+	// Local dev / preview: register a debug token so reCAPTCHA isn't required on
+	// localhost. `true` makes the SDK print a token to the console (paste it into
+	// App Check → Apps → Manage debug tokens); a string reuses that token.
+	const debugToken = import.meta.env.PUBLIC_FIREBASE_APPCHECK_DEBUG_TOKEN;
+	if (debugToken) {
+		self.FIREBASE_APPCHECK_DEBUG_TOKEN = debugToken === 'true' ? true : debugToken;
+	}
+
+	try {
+		appCheckInstance = initializeAppCheck(app, {
+			provider: new ReCaptchaEnterpriseProvider(siteKey),
+			isTokenAutoRefresh: true,
+		});
+	} catch (err) {
+		console.warn('[firebase] App Check init failed:', err);
+	}
 }
 
 let databaseInstance: Database | null = null;

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -11,7 +11,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 			<a href="/" class="back-link">&#8592; Back</a>
 
 			<h1 class="policy-title">Privacy Policy</h1>
-			<p class="policy-meta">GUG.cz, z.s. · Last updated: April 2026</p>
+			<p class="policy-meta">GUG.cz, z.s. · Last updated: June 2026</p>
 
 			<section>
 				<h2>1. Who we are</h2>
@@ -48,6 +48,20 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 					(IP address, browser, requested URL). These are retained for up to 30 days for
 					security purposes. Legal basis: legitimate interests (GDPR Art. 6(1)(f)).
 				</p>
+
+				<h3>d) Bot protection (reCAPTCHA)</h3>
+				<p>
+					To protect our ticketing data from automated scraping and abuse, the site uses
+					Google reCAPTCHA Enterprise (via Firebase App Check). reCAPTCHA runs in the background to
+					tell humans from bots, analysing signals such as your interactions with the page,
+					device and browser information, and IP address. This data is shared with Google and
+					processed under the
+					<a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Google Privacy Policy</a>
+					and
+					<a href="https://policies.google.com/terms" target="_blank" rel="noopener noreferrer">Terms of Service</a>.
+					Because this is a security measure, it runs regardless of your cookie choice.
+					Legal basis: legitimate interests (GDPR Art. 6(1)(f)).
+				</p>
 			</section>
 
 			<section>
@@ -73,6 +87,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 							<td>Google Analytics — only set after consent</td>
 							<td>2 years</td>
 						</tr>
+						<tr>
+							<th scope="row"><code>_GRECAPTCHA</code></th>
+							<td>Google reCAPTCHA — bot protection (set for security, not consent-gated)</td>
+							<td>6 months</td>
+						</tr>
 					</tbody>
 				</table>
 			</section>
@@ -81,8 +100,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 				<h2>4. Data sharing</h2>
 				<p>
 					We do not sell your data. We share it only with the processors listed above
-					(SmartEmailing, Google Firebase) under data processing agreements, and only to the
-					extent necessary to provide the services described.
+					(SmartEmailing, Google Firebase, Google reCAPTCHA) under data processing agreements,
+					and only to the extent necessary to provide the services described.
 				</p>
 			</section>
 


### PR DESCRIPTION
## Summary

Wire Firebase App Check into the web client so RTDB `/tickets` reads carry an attestation token, guarding the public ticket cache against scrapers.

- **Provider:** reCAPTCHA **Enterprise** (`ReCaptchaEnterpriseProvider`) — the legacy v3 provider is deprecated.
- **Key:** committed `APPCHECK_SITE_KEY` in `src/lib/firebase.ts` (public, like the Firebase `apiKey`). `PUBLIC_FIREBASE_APPCHECK_SITE_KEY` overrides it per environment (`src/env.d.ts` types it, `.env.example` documents it).
- **Init:** runs in `getApp()` before any `getDb()` read so the token is in place on the first read. Browser-only, fails soft.
- **Privacy policy:** discloses Google reCAPTCHA (new subsection, cookie-table row `_GRECAPTCHA`, data-sharing processor) ahead of enforcement.
- **README:** documents the register → debug-token → metrics → enforce steps.

## Why

`/tickets` is publicly readable so `Tickets.tsx` can render live release data. App Check lets us verify reads come from the real site without locking the data behind auth.

Not gated on cookie consent: `Tickets.tsx` reads `/tickets` on mount before any consent, and App Check is a security mechanism (legitimate interest), not analytics.

## Behavior

- Tokens attach to RTDB reads now, but reads **keep working until enforcement is toggled on** for Realtime Database in the Firebase console — safe to ship ahead of enforcing.
- Scope is RTDB `/tickets` only. `titoWebhook` is an external HMAC-protected ti.to caller that cannot mint a token and stays out; schedulers take no public traffic.

## Follow-up (console, not code)

1. Firebase console → App Check → Apps: register the web app, point it at the reCAPTCHA Enterprise key.
2. GCP → Security → reCAPTCHA: confirm `devfest.cz` + preview domains on the key's allowed domains.
3. Local dev: set `PUBLIC_FIREBASE_APPCHECK_DEBUG_TOKEN=true`, register the printed debug token.
4. Watch the verified/unverified split, then toggle RTDB enforcement. Leave Cloud Functions enforcement off.

## Files

- `src/lib/firebase.ts` — App Check init + committed key
- `src/env.d.ts` (new) — env var + debug-token typing
- `.env.example` (new) — env var docs
- `src/pages/privacy-policy.astro` — reCAPTCHA disclosure
- `README.md`, `CLAUDE.md` — App Check docs