### PR TITLE
fix(appcheck): update reCAPTCHA Enterprise key

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Remaining steps (do 1–3 before turning on enforcement):
 
 1. **Register the key in Firebase App Check.** GCP console (project
    `devfest-cz-app`) → Security → reCAPTCHA holds the **score-based website key**
-   (`6Lf…zV92P`); add `devfest.cz` and any preview domains to its allowed
+   (`6Ld…WChra`); add `devfest.cz` and any preview domains to its allowed
    domains. Then Firebase console → App Check → Apps: register the web app and
    point it at that reCAPTCHA Enterprise key. (Per-environment override: set
    `PUBLIC_FIREBASE_APPCHECK_SITE_KEY` in `.env` to use a different key ID.)

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -26,7 +26,7 @@ function getApp(): FirebaseApp {
 // reCAPTCHA Enterprise key ID. Public, like the Firebase `apiKey` above — safe
 // to commit. Used as the default App Check key; PUBLIC_FIREBASE_APPCHECK_SITE_KEY
 // overrides it (e.g. a separate key per environment).
-const APPCHECK_SITE_KEY = '6LftoSYtAAAAAC3KOtITOv99JybWgVfkSq-zV92P';
+const APPCHECK_SITE_KEY = '6LdOhSYtAAAAALPcqSZIJoT7i7c6B5SOiByWChra';
 
 let appCheckInstance: AppCheck | null = null;
 /**


### PR DESCRIPTION
## Summary

Swap the committed App Check reCAPTCHA Enterprise key ID (`APPCHECK_SITE_KEY` in `src/lib/firebase.ts`) to the key actually registered for the website web app in Firebase App Check.

## Why

The deployed site was failing the App Check token exchange with:

```
400 FAILED_PRECONDITION
App not registered: 1:544417536046:web:a238af229f95f75c2aa7bf
```

The prior key was not bound to this Firebase web app. Pointing the client at the correctly-registered key clears the 400 so tokens attach to RTDB reads.

## Behavior

- No logic change — one constant + its README reference. RTDB reads keep working; enforcement stays a console toggle.
- New key still needs its own Domain list (`devfest.cz`) on the GCP reCAPTCHA side; that's console config, not code.

## Files

- `src/lib/firebase.ts` — key ID
- `README.md` — key reference in the App Check section