### PR TITLE
fix(invoice): send discount email from verified devfest.cz domain

### DIFF
--- a/functions/src/invoice/params.ts
+++ b/functions/src/invoice/params.ts
@@ -38,5 +38,5 @@ export const INVOICE_VAT_RATE = 21;
 export const INVOICE_DUE_DAYS = 14;
 
 // Discount-code email sender. The domain MUST be verified in Resend.
-export const INVOICE_FROM_EMAIL = 'devfest@gug.cz';
+export const INVOICE_FROM_EMAIL = 'noreply@devfest.cz';
 export const INVOICE_FROM_NAME = 'DevFest.cz';


### PR DESCRIPTION
## Summary

Switch the invoice discount-code email sender from `devfest@gug.cz` to `noreply@devfest.cz`.

## Why

Resend rejected the discount-code email with a 403:

> `The gug.cz domain is not verified. Please, add and verify your domain on https://resend.com/domains`

`gug.cz` is not a verified Resend sending domain; `devfest.cz` is. Resend verifies the **domain**, not the local part, so any `@devfest.cz` address works.

## Behavior

`pollPaidInvoices` now sends the 100%-off discount-code email from `noreply@devfest.cz`. Requires redeploy:

```
firebase deploy --only functions:pollPaidInvoices --project devfest-cz-app
```

## Files

- `functions/src/invoice/params.ts` — `INVOICE_FROM_EMAIL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)