### PR TITLE
fix(security): harden invoice + tickets functions and cache exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Wire up the webhook in ti.to → Customize → Webhook Endpoints:
 
 `database.rules.json` documents the required rules. Either paste it into the Firebase console, or add `"database": { "rules": "database.rules.json" }` to `firebase.json` and run `firebase deploy --only database`.
 
-While the Tickets section is hidden on the site, `/tickets` is locked down (`.read: false`) so the cache cannot be pulled from outside. The Cloud Functions still write to it via the Admin SDK (which bypasses rules). When the site is ready to launch, flip `tickets.".read"` to `true` and re-deploy / re-paste the rules.
+`/tickets` is publicly readable (`tickets.".read": true`) so the browser `Tickets.tsx` subscriber can render live release data; the root default and all writes stay `false`. The Cloud Functions write the cache via the Admin SDK (which bypasses rules). Note the projected cache deliberately omits raw inventory counts (`quantity` / `quantity_sold` / `tickets_count`) and ships only a coarse `has_sales` boolean, so public reads can't derive per-wave sales velocity — see `functions/src/tickets/tito-api.ts::projectRelease`.
 
 ### App Check
 

--- a/firebase.json
+++ b/firebase.json
@@ -11,6 +11,16 @@
     "trailingSlash": false,
     "headers": [
       {
+        "source": "**",
+        "headers": [
+          { "key": "X-Frame-Options", "value": "DENY" },
+          { "key": "X-Content-Type-Options", "value": "nosniff" },
+          { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+          { "key": "Strict-Transport-Security", "value": "max-age=31536000" },
+          { "key": "Content-Security-Policy-Report-Only", "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'unsafe-inline' https://www.google.com https://www.gstatic.com https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://*.googleapis.com https://*.firebasedatabase.app wss://*.firebasedatabase.app https://*.cloudfunctions.net https://www.google-analytics.com https://www.google.com https://www.gstatic.com; frame-src https://www.google.com https://www.youtube.com; form-action 'self' https://app.smartemailing.cz" }
+        ]
+      },
+      {
         "source": "/_astro/**",
         "headers": [
           { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -11,5 +11,10 @@
  *   3. Append `export * from './<domain>/index.js';` below.
  */
 
+// Side-effect import: applies setGlobalOptions before any function is defined.
+// Must stay the first import so the defaults are in place when the domain
+// modules' function factories run.
+import './options.js';
+
 export * from './tickets/index.js';
 export * from './invoice/index.js';

--- a/functions/src/invoice/firestore.ts
+++ b/functions/src/invoice/firestore.ts
@@ -8,9 +8,12 @@
  * Lifecycle (status):
  *   pending    → form submitted, nothing sent yet
  *   invoiced   → iDoklad contact + invoice created (and emailed)
+ *   processing → poller claimed a paid invoice and is minting the code
  *   completed  → invoice paid → 100%-off ti.to code generated + delivered
  *   error      → pipeline failed; see `errorMessage`
  */
+
+import { createHash } from 'node:crypto';
 
 import { FieldValue } from 'firebase-admin/firestore';
 
@@ -18,7 +21,14 @@ import { firestore } from '../lib/admin.js';
 
 export const INVOICES_COLLECTION = 'invoices';
 
-export type InvoiceStatus = 'pending' | 'invoiced' | 'completed' | 'error';
+/**
+ * Per-(company, email) throttle counters for `submitInvoiceRequest`. Like the
+ * invoices collection, this is server-only — the catch-all deny in
+ * firestore.rules covers it (no explicit client access anywhere).
+ */
+export const INVOICE_RATE_LIMITS_COLLECTION = 'invoiceRateLimits';
+
+export type InvoiceStatus = 'pending' | 'invoiced' | 'processing' | 'completed' | 'error';
 
 /** The validated payload written by `submitInvoiceRequest`. */
 export interface InvoiceRequestInput {
@@ -86,4 +96,68 @@ export async function updateInvoice(id: string, patch: Partial<InvoiceDoc>): Pro
 	await invoicesCollection()
 		.doc(id)
 		.set({ ...patch, updatedAt: FieldValue.serverTimestamp() }, { merge: true });
+}
+
+/**
+ * Sliding-window rate limit keyed by (IČO + email), enforced in a single-doc
+ * transaction so it needs no composite index. Returns `true` when the request
+ * is within budget (and records it), `false` when the caller has exceeded
+ * `max` submissions inside `windowMs`.
+ *
+ * This is the throttle App Check cannot provide: App Check attests the caller
+ * is the real site, but a captured/valid token could otherwise drive unbounded
+ * invoice + email creation (cost / sending-reputation abuse).
+ */
+export async function checkInvoiceRateLimit(opts: {
+	registrationNumberIC: string;
+	email: string;
+	max: number;
+	windowMs: number;
+}): Promise<boolean> {
+	const key = createHash('sha256')
+		.update(`${opts.registrationNumberIC.toLowerCase()}|${opts.email.toLowerCase()}`)
+		.digest('hex');
+	const ref = firestore().collection(INVOICE_RATE_LIMITS_COLLECTION).doc(key);
+	const now = Date.now();
+
+	return firestore().runTransaction(async (tx) => {
+		const snap = await tx.get(ref);
+		const data = snap.exists ? (snap.data() as { windowStart?: number; count?: number }) : null;
+
+		if (data && typeof data.windowStart === 'number' && now - data.windowStart < opts.windowMs) {
+			if ((data.count ?? 0) >= opts.max) return false;
+			tx.update(ref, { count: (data.count ?? 0) + 1, updatedAt: FieldValue.serverTimestamp() });
+			return true;
+		}
+
+		tx.set(ref, { windowStart: now, count: 1, updatedAt: FieldValue.serverTimestamp() });
+		return true;
+	});
+}
+
+/**
+ * Atomically claim a paid invoice for post-payment processing by flipping its
+ * status `invoiced` → `processing` in a transaction. Returns `true` only for
+ * the caller that won the claim, so the 100%-off code is minted exactly once
+ * even if the poller re-enters (overlapping runs, at-least-once retries).
+ */
+export async function claimInvoiceForProcessing(id: string): Promise<boolean> {
+	const ref = invoicesCollection().doc(id);
+	return firestore().runTransaction(async (tx) => {
+		const snap = await tx.get(ref);
+		if (!snap.exists) return false;
+		if ((snap.data() as InvoiceDoc).status !== 'invoiced') return false;
+		tx.update(ref, { status: 'processing', updatedAt: FieldValue.serverTimestamp() });
+		return true;
+	});
+}
+
+/**
+ * Release a claimed invoice back to `invoiced` so the next poll retries it.
+ * Used when post-payment processing fails partway — but only when no code was
+ * minted yet (`claimInvoiceForProcessing` + persisting the code right after
+ * minting together guarantee a code is never created twice).
+ */
+export async function releaseInvoiceClaim(id: string, errorMessage: string): Promise<void> {
+	await updateInvoice(id, { status: 'invoiced', errorMessage });
 }

--- a/functions/src/invoice/poll.ts
+++ b/functions/src/invoice/poll.ts
@@ -43,7 +43,13 @@ import {
 	type TitoConfig,
 } from './tito-discount.js';
 import { buildDiscountEmail, sendEmail } from './email.js';
-import { listAwaitingPayment, updateInvoice, type InvoiceRecord } from './firestore.js';
+import {
+	claimInvoiceForProcessing,
+	listAwaitingPayment,
+	releaseInvoiceClaim,
+	updateInvoice,
+	type InvoiceRecord,
+} from './firestore.js';
 import { notify } from './slack.js';
 
 const REGION = 'europe-west1';
@@ -74,16 +80,35 @@ export const pollPaidInvoices = onSchedule(
 
 		let completed = 0;
 		for (const record of awaiting) {
+			if (record.data.idokladInvoiceId == null) continue;
+
+			let status: number;
 			try {
-				if (record.data.idokladInvoiceId == null) continue;
-				const status = await getInvoicePaymentStatus(idokladCfg, record.data.idokladInvoiceId);
-				if (!isPaidStatus(status)) continue;
-				await completeInvoice(record, idokladCfg, titoCfg, slackUrl);
+				status = await getInvoicePaymentStatus(idokladCfg, record.data.idokladInvoiceId);
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				logger.error('pollPaidInvoices: payment status check failed', { id: record.id, message });
+				continue;
+			}
+			if (!isPaidStatus(status)) continue;
+
+			// Atomically claim invoiced→processing so the code is minted once
+			// even if a previous run already picked this doc up.
+			if (!(await claimInvoiceForProcessing(record.id))) continue;
+
+			try {
+				await completeInvoice(record, titoCfg, slackUrl);
 				completed += 1;
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				logger.error('pollPaidInvoices: failed to complete invoice', { id: record.id, message });
-				await notify(slackUrl, `❌ ${record.data.companyName} — post-payment processing failed: ${message}`);
+				// Revert to `invoiced` so the next poll retries. Safe to re-run:
+				// the code is persisted the instant it's minted, so completeInvoice
+				// never mints a second one.
+				await releaseInvoiceClaim(record.id, message);
+				// Keep upstream error detail in logs only — don't echo (potential
+				// PII) into the Slack channel.
+				await notify(slackUrl, `❌ ${record.data.companyName} — post-payment processing failed (id ${record.id}); see logs`);
 			}
 		}
 		logger.info('pollPaidInvoices done', { checked: awaiting.length, completed });
@@ -92,31 +117,42 @@ export const pollPaidInvoices = onSchedule(
 
 async function completeInvoice(
 	record: InvoiceRecord,
-	idokladCfg: IdokladConfig,
 	titoCfg: TitoConfig,
 	slackUrl: string,
 ): Promise<void> {
 	const { id, data } = record;
 
-	const releases = await resolveCompanyFundedReleases(titoCfg, INVOICE_RELEASE_MATCH);
-	const releaseIds = releases.map((r) => r.id);
-	if (releaseIds.length === 0) {
-		throw new Error(`No ti.to release matched "${INVOICE_RELEASE_MATCH}"`);
-	}
+	// Idempotent mint: if a code was already created on a prior (partial) run,
+	// reuse it instead of minting a second one. The code is deterministic, so a
+	// re-mint would otherwise collide on ti.to.
+	let code = data.discountCode ?? null;
+	let link = data.discountLink ?? null;
 
-	const code = buildDiscountCode(data.companyName, id.slice(-6));
-	const created = await createDiscountCode(titoCfg, {
-		code,
-		quantity: data.countTickets,
-		releaseIds,
-	});
-	const link = discountRedeemUrl(titoCfg, created.code);
+	if (!code) {
+		const releases = await resolveCompanyFundedReleases(titoCfg, INVOICE_RELEASE_MATCH);
+		const releaseIds = releases.map((r) => r.id);
+		if (releaseIds.length === 0) {
+			throw new Error(`No ti.to release matched "${INVOICE_RELEASE_MATCH}"`);
+		}
+
+		const created = await createDiscountCode(titoCfg, {
+			code: buildDiscountCode(data.companyName, id.slice(-6)),
+			quantity: data.countTickets,
+			releaseIds,
+		});
+		code = created.code;
+		link = discountRedeemUrl(titoCfg, created.code);
+
+		// Persist the code BEFORE attempting delivery, so a later failure never
+		// re-mints — the next run sees the code and skips creation.
+		await updateInvoice(id, { discountCode: code, discountLink: link });
+	}
 
 	let discountEmailSent = false;
 	try {
 		const mail = buildDiscountEmail({
-			code: created.code,
-			link,
+			code,
+			link: link ?? '',
 			ticketCount: data.countTickets,
 			companyName: data.companyName,
 		});
@@ -135,7 +171,7 @@ async function completeInvoice(
 
 	await updateInvoice(id, {
 		status: 'completed',
-		discountCode: created.code,
+		discountCode: code,
 		discountLink: link,
 		discountEmailSent,
 		errorMessage: null,
@@ -143,11 +179,11 @@ async function completeInvoice(
 
 	const emailNote = discountEmailSent
 		? 'code emailed'
-		: `⚠️ email not sent — send code manually: ${created.code} (${link})`;
+		: `⚠️ email not sent — send code manually: ${code} (${link})`;
 	await notify(
 		slackUrl,
-		`${data.companyName} — paid, code ${created.code} generated ` +
+		`${data.companyName} — paid, code ${code} generated ` +
 			`for ${data.countTickets}× ticket; ${emailNote}`,
 	);
-	logger.info('completeInvoice completed', { id, code: created.code });
+	logger.info('completeInvoice completed', { id, code });
 }

--- a/functions/src/invoice/process.ts
+++ b/functions/src/invoice/process.ts
@@ -154,8 +154,11 @@ export const processInvoiceRequest = onDocumentCreated(
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
 			logger.error('processInvoiceRequest failed', err);
+			// errorMessage stays in Firestore (server-only, deny-all rules). The
+			// Slack channel gets a generic line — upstream error bodies can echo
+			// submitted PII (IČO/DIČ/address), so they don't belong there.
 			await updateInvoice(id, { status: 'error', errorMessage: message });
-			await notify(slackUrl, `❌ ${doc.companyName} — invoice creation failed: ${message}`);
+			await notify(slackUrl, `❌ ${doc.companyName} — invoice creation failed (id ${id}); see logs`);
 		}
 	},
 );

--- a/functions/src/invoice/submit.ts
+++ b/functions/src/invoice/submit.ts
@@ -7,21 +7,31 @@
  * (firestore.rules denies all) and untrusted input is validated before it
  * ever reaches iDoklad.
  *
- * Abuse protection: `enforceAppCheck: true` makes the callable reject any
- * request without a valid Firebase App Check token (reCAPTCHA Enterprise)
- * before the handler runs — the client SDK attaches the token automatically,
- * so bots/curl that can't mint an attestation are blocked. The callable
- * protocol also handles CORS, so there's nothing to wire by hand.
+ * Abuse protection (layered, because App Check alone is attestation, not a
+ * throttle):
+ *   - `enforceAppCheck: true` rejects any request without a valid Firebase
+ *     App Check token (reCAPTCHA Enterprise) before the handler runs — blocks
+ *     bots/curl that can't mint an attestation.
+ *   - a per-(IČO + email) sliding-window rate limit caps how many invoices +
+ *     emails one company can drive (cost / sending-reputation abuse).
+ *   - `maxInstances` caps fan-out on the shared billing project.
+ * (Token replay protection — `consumeAppCheckToken` + limited-use client
+ * tokens — is intentionally NOT enabled: low-threat site, not worth the
+ * client/server coupling.)
+ * The callable protocol also handles CORS, so there's nothing to wire by hand.
  */
 
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import { logger } from 'firebase-functions/v2';
 
-import { createInvoiceRequest, type InvoiceRequestInput } from './firestore.js';
+import { checkInvoiceRateLimit, createInvoiceRequest, type InvoiceRequestInput } from './firestore.js';
 
 const REGION = 'europe-west1';
 const MAX_TICKETS = 50;
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// At most this many submissions per (company, email) inside the window.
+const RATE_LIMIT_MAX = 3;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 
 type ValidationResult =
 	| { ok: true; value: InvoiceRequestInput }
@@ -75,6 +85,7 @@ export const submitInvoiceRequest = onCall(
 	{
 		region: REGION,
 		enforceAppCheck: true,
+		maxInstances: 10,
 		memory: '256MiB',
 		timeoutSeconds: 30,
 	},
@@ -91,6 +102,19 @@ export const submitInvoiceRequest = onCall(
 		if (!result.ok) {
 			// `message` carries the offending field so the form can point at it.
 			throw new HttpsError('invalid-argument', result.error);
+		}
+
+		// Throttle per (company, email) so one valid App Check token can't drive
+		// unbounded invoice + email creation.
+		const allowed = await checkInvoiceRateLimit({
+			registrationNumberIC: result.value.registrationNumberIC,
+			email: result.value.email,
+			max: RATE_LIMIT_MAX,
+			windowMs: RATE_LIMIT_WINDOW_MS,
+		});
+		if (!allowed) {
+			logger.warn('submitInvoiceRequest rate limited', { ic: result.value.registrationNumberIC });
+			throw new HttpsError('resource-exhausted', 'rate_limited');
 		}
 
 		try {

--- a/functions/src/options.ts
+++ b/functions/src/options.ts
@@ -1,0 +1,18 @@
+/**
+ * Project-wide Cloud Functions defaults.
+ *
+ * Imported FIRST from `index.ts` so `setGlobalOptions` runs before any
+ * function factory (onCall/onRequest/onSchedule) executes — otherwise the
+ * defaults wouldn't apply. ES modules evaluate imports in source order, so the
+ * leading `import './options.js'` in the barrel guarantees this side effect
+ * lands before the domain modules load.
+ *
+ * `maxInstances` is a cost ceiling: this codebase shares a billing project
+ * with the mobile-app team, so a retry storm or the public `titoWebhook` flood
+ * path must not be able to fan out unboundedly. Per-function overrides (e.g.
+ * the tighter cap on `submitInvoiceRequest`) still win where set.
+ */
+
+import { setGlobalOptions } from 'firebase-functions/v2';
+
+setGlobalOptions({ maxInstances: 10 });

--- a/functions/src/tickets/notify-purchase.ts
+++ b/functions/src/tickets/notify-purchase.ts
@@ -11,6 +11,7 @@
 import { logger } from 'firebase-functions/v2';
 import { onRequest } from 'firebase-functions/v2/https';
 
+import { db } from '../lib/admin.js';
 import { SLACK_WEBHOOK_URL, TITO_WEBHOOK_SECRET } from './params.js';
 import { postToSlack, type SlackPayload } from './slack-client.js';
 import {
@@ -25,6 +26,54 @@ import {
 const REGION = 'europe-west1';
 
 const NOTIFY_EVENT: TitoWebhookEvent = 'registration.finished';
+
+// ti.to signs the body but adds no timestamp/nonce, so a captured valid POST
+// could be replayed verbatim. Dedup on the registration reference for a day so
+// a replay is acked (200) without re-posting to Slack.
+const DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Claim a registration reference for processing. Returns `true` only the first
+ * time a reference is seen within the window (RTDB transaction, server-only
+ * path — root rules deny client access). Returns `true` as a fail-open default
+ * if the reference is missing or the dedup store errors, so a transient RTDB
+ * issue never drops a real notification.
+ */
+function dedupRef(reference: string) {
+	const key = reference.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 256);
+	return db().ref(`webhookDedup/registrations/${key}`);
+}
+
+async function claimRegistrationReference(reference: string | undefined): Promise<boolean> {
+	if (!reference) return true;
+	try {
+		const result = await dedupRef(reference).transaction((current: { at?: number } | null) => {
+			const now = Date.now();
+			if (current && typeof current.at === 'number' && now - current.at < DEDUP_WINDOW_MS) {
+				return undefined; // abort — already seen recently
+			}
+			return { at: now };
+		});
+		return result.committed;
+	} catch (err) {
+		logger.error('titoWebhook dedup check failed — proceeding', err);
+		return true;
+	}
+}
+
+/**
+ * Undo a claim so a retry can re-process. Called when Slack delivery fails
+ * after we claimed the reference — otherwise ti.to's retry would be deduped
+ * away and the notification lost.
+ */
+async function releaseRegistrationReference(reference: string | undefined): Promise<void> {
+	if (!reference) return;
+	try {
+		await dedupRef(reference).remove();
+	} catch (err) {
+		logger.error('titoWebhook dedup release failed', err);
+	}
+}
 
 function formatPrice(price: string | null | undefined, currency: string | null | undefined): string | null {
 	if (!price) return null;
@@ -162,6 +211,14 @@ export const titoWebhook = onRequest(
 			return;
 		}
 
+		// Replay guard: ack duplicates without re-posting to Slack.
+		const reference = payload.registration_reference ?? payload.reference;
+		if (!(await claimRegistrationReference(reference))) {
+			logger.info('titoWebhook duplicate delivery ignored', { reference });
+			res.status(200).send('duplicate');
+			return;
+		}
+
 		try {
 			const message = buildSlackMessage(payload);
 			await postToSlack(SLACK_WEBHOOK_URL.value(), message);
@@ -172,6 +229,8 @@ export const titoWebhook = onRequest(
 			res.status(200).send('ok');
 		} catch (err) {
 			logger.error('titoWebhook failed to notify Slack', err);
+			// Undo the dedup claim so ti.to's retry isn't silently deduped away.
+			await releaseRegistrationReference(reference);
 			// 500 lets ti.to retry the delivery.
 			res.status(500).send('Slack post failed');
 		}

--- a/functions/src/tickets/tito-api.ts
+++ b/functions/src/tickets/tito-api.ts
@@ -102,6 +102,13 @@ export function releaseTitle(r: TitoRelease): string {
  *
  * The synthetic `sale_status` (computed via `deriveSaleStatus`) is added
  * by `projectRelease` so the browser does not need to know the flag set.
+ *
+ * Deliberately NOT projected: `quantity`, `quantity_sold`, `tickets_count`.
+ * `/tickets` is world-readable, so publishing raw inventory/sold counts would
+ * leak per-wave sales velocity and remaining capacity to anyone polling RTDB.
+ * The browser only needs to know whether a paused wave has ever sold a ticket
+ * (to tell "Paused" from "Coming soon"), so we emit a single coarse
+ * `has_sales` boolean instead — see `projectRelease`.
  */
 export const RELEASE_FIELDS = [
 	'id',
@@ -113,9 +120,6 @@ export const RELEASE_FIELDS = [
 	'tax_exclusive',
 	'tax_description',
 	'currency',
-	'quantity',
-	'quantity_sold',
-	'tickets_count',
 	'state_name',
 	'sold_out',
 	'off_sale',
@@ -135,6 +139,8 @@ export function projectRelease(release: TitoRelease): Record<string, unknown> {
 		out[key] = value === undefined ? null : value;
 	}
 	out.sale_status = deriveSaleStatus(release);
+	// Coarse boolean instead of raw counts — see RELEASE_FIELDS note.
+	out.has_sales = (release.tickets_count ?? release.quantity_sold ?? 0) > 0;
 	return out;
 }
 

--- a/src/lib/tito.ts
+++ b/src/lib/tito.ts
@@ -34,9 +34,14 @@ export interface TitoRelease {
 	/** Free-text tax label set by organizer (e.g. "VAT 21%"). */
 	tax_description?: string | null;
 	currency: string | null;
-	quantity: number | null;
-	quantity_sold: number;
-	tickets_count?: number;
+	/**
+	 * Coarse "has this wave ever sold a ticket?" flag, computed server-side.
+	 * Replaces the raw `quantity` / `quantity_sold` / `tickets_count` counts,
+	 * which are intentionally NOT published to the world-readable `/tickets`
+	 * cache (they'd leak sales velocity). See
+	 * `functions/src/tickets/tito-api.ts::projectRelease`.
+	 */
+	has_sales?: boolean;
 	/** Synthetic status computed by the Cloud Function from ti.to flags. */
 	sale_status: TitoSaleStatus;
 	state_name?: string | null;
@@ -101,7 +106,7 @@ export function releaseStatus(release: TitoRelease): ReleaseStatus {
 		case 'on_sale':
 			return { label: 'On sale', tone: 'on-sale', purchasable: true };
 		case 'paused':
-			if ((release.tickets_count ?? release.quantity_sold ?? 0) === 0) {
+			if (!release.has_sales) {
 				return { label: 'Coming soon', tone: 'soon', purchasable: false };
 			}
 			return { label: 'Paused', tone: 'paused', purchasable: false };


### PR DESCRIPTION
## Summary

Follow-up to a deep security audit of the Cloud Functions + public RTDB cache. No critical/high vulnerabilities existed; this closes the confirmed low/medium gaps and adds defense-in-depth. App Check **token replay protection was intentionally left out** — low-threat site, not worth the client/server coupling.

## Why

The invoice callable could be driven repeatedly by a single valid App Check token (cost / email-reputation abuse), the public `/tickets` cache leaked raw per-wave sales numbers, the payout poller could mint a duplicate 100%-off code after a partial failure, and upstream error bodies (which can echo submitted PII) were posted to Slack.

## Behavior

- **Invoice submit** — per-(IČO+email) sliding-window rate limit (3/hr, single-doc transaction, no composite index) + `maxInstances`. `enforceAppCheck` + honeypot unchanged.
- **Invoice payout** — idempotent: atomic `invoiced→processing` claim, discount code persisted the instant it's minted, revert-to-`invoiced` on failure → no duplicate codes on re-entry.
- **Tickets cache** — `quantity` / `quantity_sold` / `tickets_count` no longer published to the world-readable `/tickets`; a coarse `has_sales` boolean replaces them. `releaseStatus()` updated (logically equivalent to the old zero-check).
- **ti.to webhook** — replay dedup on `registration_reference` (RTDB txn, 24h), with claim release on Slack-post failure so legitimate ti.to retries still deliver.
- **Slack** — generic failure lines; raw upstream error detail stays in logs + server-only `errorMessage`.
- **Functions** — project-wide `maxInstances` via `setGlobalOptions` (side-effect import ordered before the function factories).
- **Hosting** — `X-Frame-Options: DENY`, `nosniff`, `Referrer-Policy`, HSTS, and a **report-only** CSP scoped to the real origins (Firebase, reCAPTCHA, GA, fonts, SmartEmailing).
- **Docs** — corrected README `/tickets` `.read` drift and documented the `has_sales` coarsening.

## Verification

- `npm --prefix functions run build` (tsc) — clean
- `npm run build` (Astro) — clean
- `firebase.json` parses as valid JSON
- Independent diff review for regressions — no findings

## Deploy notes (manual, per shared-project setup)

- Rules are pasted into the console by hand. New server-only stores are covered by existing deny-all (Firestore `invoiceRateLimits` → catch-all deny; RTDB `webhookDedup/*` → root `.read/.write:false`). Confirm those catch-alls are still present.
- CSP ships **report-only** — watch reports, then promote to enforced `Content-Security-Policy`. Tighten HSTS (`includeSubDomains; preload`) once no plain-http subdomain is in use.
- After deploy, the `/tickets` cache keeps its old shape until the next hourly `refreshTitoCache` — a paused-with-sales wave shows "Coming soon" instead of "Paused" until then. Run `refreshTitoCache` once to refresh immediately.
- Smoke-test the `/invoice` form submit on the preview deploy.