### PR TITLE
feat(home): partners strip + unified homepage design

### DIFF
--- a/src/lib/partners.ts
+++ b/src/lib/partners.ts
@@ -1,0 +1,18 @@
+// Single source of truth for partner logos, shared by the dedicated
+// /partners page and the homepage partners teaser.
+//
+// Logos live under public/partners/<tier>/. Add an entry per partner:
+// { name, logo, url? } — `url` optional.
+export type Partner = { name: string; logo: string; url?: string };
+
+// Silver tier (and above). Full wordmarks ship light (white cut-out) for the
+// dark card. The homepage shows these "silver+" partners — media is excluded.
+export const silverPartners: Partner[] = [
+	{ name: 'Applifting', logo: '/partners/silver/applifting.png', url: 'https://www.applifting.io/' },
+];
+
+// Media partners — only shown on the dedicated /partners page, never the homepage.
+export const mediaPartners: Partner[] = [
+	{ name: 'White Whale Media', logo: '/partners/media/whitewhalemedia.svg', url: 'https://www.whitewhale.media/' },
+	{ name: 'Dotěkománie', logo: '/partners/media/dotekomanie.avif', url: 'https://dotekomanie.cz/' },
+];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import Footer from '../components/Footer.astro';
 import HeroBackground from '../components/HeroBackground.astro';
 import Ticker from '../components/Ticker.astro';
 import Tickets from '../components/Tickets';
+import { silverPartners } from '../lib/partners';
 
 const tickerTopics = [
 	'AI & Machine Learning',
@@ -77,6 +78,9 @@ const tickerTopics = [
 		<!-- TICKER -->
 		<Ticker items={tickerTopics} />
 
+		<!-- TICKETS -->
+		<Tickets client:visible />
+
 		<!-- CALL FOR SPEAKERS -->
 		<section id="speakers" aria-labelledby="speakers-title">
 			<div class="speakers-inner">
@@ -99,12 +103,39 @@ const tickerTopics = [
 			</div>
 		</section>
 
-		<!-- TICKETS -->
-		<Tickets client:visible />
+		<!-- PARTNERS — quiet silver+ strip; media partners live on /partners only -->
+		{silverPartners.length > 0 && (
+			<section id="partners" aria-labelledby="partners-title">
+				<div class="partners-inner">
+					<p id="partners-title" class="section-label">Partners</p>
+
+					<ul class="partners-row">
+						{silverPartners.map((p) => (
+							<li class="partners-item">
+								{p.url ? (
+									<a href={p.url} target="_blank" rel="noopener noreferrer" aria-label={p.name}>
+										<img class="partners-logo" src={p.logo} alt={p.name} loading="lazy" />
+									</a>
+								) : (
+									<img class="partners-logo" src={p.logo} alt={p.name} loading="lazy" />
+								)}
+							</li>
+						))}
+
+						<li class="partners-more">
+							<a href="/partners">
+								See all
+								<span class="btn-ghost-arrow" aria-hidden="true">&#8600;</span>
+							</a>
+						</li>
+					</ul>
+				</div>
+			</section>
+		)}
 
 		<!-- GALLERY — photos from past editions -->
 		<section id="gallery" aria-labelledby="gallery-title">
-			<div class="gallery-head section-head">
+			<div class="gallery-head">
 				<p class="section-label">Past editions</p>
 				<h2 id="gallery-title" class="section-title">Past <span class="red">DevFests</span></h2>
 				<p class="gallery-lede">

--- a/src/pages/index.scss
+++ b/src/pages/index.scss
@@ -217,22 +217,8 @@
 	#gallery {
 		position: relative;
 		padding: 8.5rem 0 8rem;
-		background:
-			linear-gradient(180deg, var(--color-bg) 0%, var(--color-near-black) 28%, var(--color-near-black) 72%, var(--color-bg) 100%);
+		background: var(--color-bg);
 		overflow: hidden;
-		border-top: 1px solid rgba(204, 0, 0, 0.18);
-		border-bottom: 1px solid rgba(204, 0, 0, 0.18);
-
-		&::before {
-			content: '';
-			position: absolute;
-			inset: 0;
-			background:
-				radial-gradient(ellipse 55% 70% at 85% 15%, rgba(204, 0, 0, 0.09) 0%, transparent 62%),
-				radial-gradient(ellipse 45% 65% at 8% 92%, rgba(139, 24, 24, 0.08) 0%, transparent 60%);
-			pointer-events: none;
-			z-index: 0;
-		}
 
 		// faint horizontal "evidence rail" line behind photos
 		&::after {
@@ -263,7 +249,15 @@
 		padding: 0 3rem;
 		display: flex;
 		flex-direction: column;
-		align-items: flex-start;
+		align-items: center;
+		text-align: center;
+
+		.section-label {
+			justify-content: center;
+
+			// trailing hairline reads off-centre on a centred eyebrow
+			&::after { display: none; }
+		}
 	}
 
 	.gallery-head .section-title {
@@ -277,7 +271,7 @@
 		line-height: 1.7;
 		color: var(--color-grey);
 		max-width: 520px;
-		margin: 0;
+		margin: 0 auto;
 	}
 
 	.gallery-marquee {
@@ -358,19 +352,6 @@
 		width: 100%;
 		overflow: hidden;
 		background: var(--color-bg);
-		border-top: 1px solid rgba(204, 0, 0, 0.18);
-		border-bottom: 1px solid rgba(204, 0, 0, 0.18);
-
-		&::before {
-			content: '';
-			position: absolute;
-			inset: 0;
-			background:
-				radial-gradient(ellipse 50% 60% at 15% 8%, rgba(204, 0, 0, 0.1) 0%, transparent 60%),
-				radial-gradient(ellipse 45% 65% at 88% 96%, rgba(139, 24, 24, 0.09) 0%, transparent 60%);
-			pointer-events: none;
-			z-index: 0;
-		}
 	}
 
 	.speakers-inner {
@@ -518,6 +499,115 @@
 		margin-bottom: 2.6rem;
 	}
 
+	/* ===================== PARTNERS ===================== */
+	// Deliberately quiet: a thin band, no cards, no loud display title — just an
+	// eyebrow over a muted logo row so it sits under the gallery without
+	// competing with the hero / newsletter for attention.
+	#partners {
+		position: relative;
+		padding: 4.5rem 3rem;
+		width: 100%;
+		background: var(--color-bg);
+	}
+
+	.partners-inner {
+		position: relative;
+		z-index: 1;
+		max-width: 1080px;
+		margin: 0 auto;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+	}
+
+	#partners .section-label {
+		justify-content: center;
+		margin-bottom: 2rem;
+
+		// trailing hairline reads off-centre on a centred eyebrow
+		&::after { display: none; }
+	}
+
+	.partners-row {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: center;
+		gap: 2.4rem 3.4rem;
+	}
+
+	// No card — logos float on the section bg, dimmed and slightly desaturated
+	// so they read as a supporting credit, not a billboard. Brighten on hover.
+	.partners-item {
+		display: flex;
+		align-items: center;
+
+		a {
+			display: inline-flex;
+			align-items: center;
+		}
+
+		.partners-logo {
+			display: block;
+			width: auto;
+			height: auto;
+			max-height: 56px;
+			max-width: 220px;
+			object-fit: contain;
+			opacity: 0.55;
+			filter: grayscale(0.4);
+			transition: opacity 0.2s, filter 0.2s;
+		}
+
+		a:hover .partners-logo,
+		a:focus-visible .partners-logo {
+			opacity: 1;
+			filter: grayscale(0);
+		}
+
+		a:focus-visible {
+			outline: 2px solid var(--color-accent-hot);
+			outline-offset: 6px;
+		}
+	}
+
+	// Inline "See all" sits in the same row as the logos — quiet mono link.
+	.partners-more a {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		font-family: 'Share Tech Mono', monospace;
+		font-size: 0.74rem;
+		letter-spacing: 0.22em;
+		text-transform: uppercase;
+		color: rgba(240, 237, 230, 0.62);
+		text-decoration: none;
+		transition: color 0.2s, gap 0.2s;
+
+		.btn-ghost-arrow { transition: transform 0.25s; }
+
+		&:hover,
+		&:focus-visible {
+			color: var(--color-accent-hot);
+			gap: 0.7rem;
+			outline: none;
+		}
+
+		&:hover .btn-ghost-arrow,
+		&:focus-visible .btn-ghost-arrow {
+			transform: translate(2px, 2px);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--color-accent-hot);
+			outline-offset: 4px;
+		}
+	}
+
 	/* ===================== RESPONSIVE ===================== */
 	@media (max-width: 1240px) {
 		.hero-grid {
@@ -567,6 +657,8 @@
 		.hero-countdown { padding: 1.6rem 1.2rem 1.4rem; }
 		#newsletter { padding: 6.5rem 1.5rem; }
 		#speakers { padding: 6.5rem 1.5rem; }
+		#partners { padding: 4rem 1.5rem; }
+		.partners-row { gap: 2rem 2.6rem; }
 		#gallery { padding: 6.5rem 0 6rem; }
 		.gallery-head { padding: 0 1.5rem; margin-bottom: 3.5rem; }
 		.gallery-marquee { padding: 1.8rem 0; }
@@ -598,6 +690,9 @@
 		.section-label::after { flex-basis: 32px; }
 		#newsletter { padding: 5rem 1.1rem; }
 		#speakers { padding: 5rem 1.1rem; }
+		#partners { padding: 3.5rem 1.1rem; }
+		.partners-row { gap: 1.8rem 2.2rem; }
+		.partners-item .partners-logo { max-height: 46px; max-width: 180px; }
 	}
 
 	@media (max-width: 380px) {
@@ -608,6 +703,7 @@
 		.btn-ghost { font-size: 0.82rem; letter-spacing: 0.18em; }
 		#newsletter { padding: 4.5rem 0.85rem; }
 		#speakers { padding: 4.5rem 0.85rem; }
+		#partners { padding: 3rem 0.85rem; }
 	}
 
 	@media (prefers-reduced-motion: reduce) {

--- a/src/pages/partners.astro
+++ b/src/pages/partners.astro
@@ -3,24 +3,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Footer from '../components/Footer.astro';
 import SubpageHero from '../components/SubpageHero.astro';
 import Ticker from '../components/Ticker.astro';
+import { silverPartners, mediaPartners } from '../lib/partners';
 
 const DECK_READY = true;
 const PRESENTATION_URL = 'https://canva.link/828fiq93km2hwds';
 const FILIP = { name: 'Filip Goszler', role: 'Partnerships', email: 'filip@gug.cz' };
-
-// Silver partners — logos live in public/partners/silver/.
-// Full wordmarks ship light (white cut-out) for the dark card.
-// Add an entry per partner: { name, logo, url? }. `url` optional.
-const silverPartners: { name: string; logo: string; url?: string }[] = [
-	{ name: 'Applifting', logo: '/partners/silver/applifting.png', url: 'https://www.applifting.io/' },
-];
-
-// Media partners — logos live in public/partners/media/.
-// Add an entry per partner: { name, logo, url? }. `url` optional.
-const mediaPartners: { name: string; logo: string; url?: string }[] = [
-	{ name: 'White Whale Media', logo: '/partners/media/whitewhalemedia.svg', url: 'https://www.whitewhale.media/' },
-	{ name: 'Dotěkománie', logo: '/partners/media/dotekomanie.avif', url: 'https://dotekomanie.cz/' },
-];
 
 const tickerTopics = [
 	'Reach Developers',


### PR DESCRIPTION
## Summary

- Add a quiet **silver+ partners** strip to the homepage (media partners excluded). Muted logos on the dark canvas with a "See all" link → `/partners`. Mirrors last year's homepage partners teaser.
- Extract partner data into `src/lib/partners.ts` — single source shared by the homepage and the `/partners` page (no more duplicated arrays).
- **Reorder** homepage so Tickets lead: hero → tickets → CFP (Call for speakers) → partners → gallery → newsletter.
- **Center** the gallery heading + lede ("Past DevFests").
- **De-box** the page so it reads as one continuous design instead of stacked boxes: removed the hard red section borders, the gallery's distinct background, and the per-section red radial glows. All sections now share one dark canvas; ambient red still comes from the global BaseLayout glow.

## Why

The homepage had no partners presence, and partner data lived only on `/partners`. The added section surfaces sponsors on the landing page. While integrating it, the section dividers (red hairline borders + corner glows) made the page look chopped into separate boxes — unified to a single cohesive noir canvas.

## Behavior

- Partners section only renders when at least one silver+ partner exists.
- Media partners remain on `/partners` only — never on the homepage.
- `/partners` page output unchanged (still full cards); it now imports its data from `src/lib/partners.ts`.

## Files

- `src/lib/partners.ts` — new shared partner data module.
- `src/pages/index.astro` — partners section, section reorder, centered gallery head.
- `src/pages/index.scss` — partners strip styles; removed section borders, gallery bg, and red radial glows; centered gallery head.
- `src/pages/partners.astro` — import partner data from lib.